### PR TITLE
Improve handling of client secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ module "web_app" {
   resource_group_name = azurerm_resource_group.example.name
 
   azuread_client_id             = "6b5fbe59-9c49-488f-959f-82cada7abf14"
-  azuread_client_secret_setting = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.example.id})"
+  azuread_client_key_vault_name = module.vault.key_vault_name
+  azuread_client_secret_name    = azurerm_key_vault_secret.example.name
 
   acr_identity_client_id = module.acr.user_assigned_identity_client_id
   acr_identity_id        = module.acr.user_assigned_identity_id

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ No modules.
 | <a name="input_app_settings"></a> [app\_settings](#input\_app\_settings) | A map of key-value pairs of App Settings. | `map(string)` | `{}` | no |
 | <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |
 | <a name="input_azuread_client_id"></a> [azuread\_client\_id](#input\_azuread\_client\_id) | The ID of the Client to use to authenticate with Azure Active Directory. | `string` | n/a | yes |
-| <a name="input_azuread_client_secret_setting"></a> [azuread\_client\_secret\_setting](#input\_azuread\_client\_secret\_setting) | The value of the App Setting that contains the client secret of the Client. | `string` | n/a | yes |
+| <a name="input_azuread_client_secret_name"></a> [azuread\_client\_secret\_name](#input\_azuread\_client\_secret\_name) | The name of the Key Vault Secret containing the Client Secret. | `string` | n/a | yes |
+| <a name="input_azuread_client_vault_name"></a> [azuread\_client\_vault\_name](#input\_azuread\_client\_vault\_name) | The name of the Key Vault where the Client Secret is stored. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment to create the resources for. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Specifies the supported Azure location where the resources exist. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group in which to create the resources. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ module "web_app" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
-  azuread_client_id             = "6b5fbe59-9c49-488f-959f-82cada7abf14"
-  azuread_key_vault_name        = module.vault.key_vault_name
-  azuread_key_vault_secret_name = azurerm_key_vault_secret.example.name
+  azuread_client_id          = "6b5fbe59-9c49-488f-959f-82cada7abf14"
+  azuread_client_vault_name  = module.vault.key_vault_name
+  azuread_client_secret_name = azurerm_key_vault_secret.example.name
 
   acr_identity_client_id = module.acr.user_assigned_identity_client_id
   acr_identity_id        = module.acr.user_assigned_identity_id

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ module "web_app" {
   resource_group_name = azurerm_resource_group.example.name
 
   azuread_client_id             = "6b5fbe59-9c49-488f-959f-82cada7abf14"
-  azuread_client_key_vault_name = module.vault.key_vault_name
-  azuread_client_secret_name    = azurerm_key_vault_secret.example.name
+  azuread_key_vault_name        = module.vault.key_vault_name
+  azuread_key_vault_secret_name = azurerm_key_vault_secret.example.name
 
   acr_identity_client_id = module.acr.user_assigned_identity_client_id
   acr_identity_id        = module.acr.user_assigned_identity_id

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_linux_web_app" "this" {
 
   https_only = true
 
-  app_settings = merge({ ACTIVE_DIRECTORY_AUTHENTICATION_SECRET = var.azuread_client_secret_setting }, var.app_settings)
+  app_settings = merge({ ACTIVE_DIRECTORY_AUTHENTICATION_SECRET = "@Microsoft.KeyVault(VaultName=${azuread_client_key_vault_name};SecretName=${azuread_client_secret_name})" }, var.app_settings)
 
   tags = local.tags
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_linux_web_app" "this" {
 
   https_only = true
 
-  app_settings = merge({ ACTIVE_DIRECTORY_AUTHENTICATION_SECRET = "@Microsoft.KeyVault(VaultName=${azuread_client_key_vault_name};SecretName=${azuread_client_secret_name})" }, var.app_settings)
+  app_settings = merge({ ACTIVE_DIRECTORY_AUTHENTICATION_SECRET = "@Microsoft.KeyVault(VaultName=${var.azuread_key_vault_name};SecretName=${var.azuread_key_vault_secret_name})" }, var.app_settings)
 
   tags = local.tags
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_linux_web_app" "this" {
 
   https_only = true
 
-  app_settings = merge({ ACTIVE_DIRECTORY_AUTHENTICATION_SECRET = "@Microsoft.KeyVault(VaultName=${var.azuread_key_vault_name};SecretName=${var.azuread_key_vault_secret_name})" }, var.app_settings)
+  app_settings = merge({ ACTIVE_DIRECTORY_AUTHENTICATION_SECRET = "@Microsoft.KeyVault(VaultName=${var.azuread_client_vault_name};SecretName=${var.azuread_client_secret_name})" }, var.app_settings)
 
   tags = local.tags
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -67,8 +67,8 @@ module "web_app" {
   resource_group_name = azurerm_resource_group.this.name
 
   azuread_client_id             = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
-  azuread_client_key_vault_name = module.vault.key_vault_name
-  azuread_client_secret_name    = azurerm_key_vault_secret.this.name
+  azuread_key_vault_name        = module.vault.key_vault_name
+  azuread_key_vault_secret_name = azurerm_key_vault_secret.this.name
 
   acr_identity_client_id = module.acr.user_assigned_identity_client_id
   acr_identity_id        = module.acr.user_assigned_identity_id

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -67,7 +67,8 @@ module "web_app" {
   resource_group_name = azurerm_resource_group.this.name
 
   azuread_client_id             = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
-  azuread_client_secret_setting = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.this.versionless_id})"
+  azuread_client_key_vault_name = module.vault.key_vault_name
+  azuread_client_secret_name    = azurerm_key_vault_secret.this.name
 
   acr_identity_client_id = module.acr.user_assigned_identity_client_id
   acr_identity_id        = module.acr.user_assigned_identity_id

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -66,9 +66,9 @@ module "web_app" {
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 
-  azuread_client_id             = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
-  azuread_key_vault_name        = module.vault.key_vault_name
-  azuread_key_vault_secret_name = azurerm_key_vault_secret.this.name
+  azuread_client_id          = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
+  azuread_client_vault_name  = module.vault.key_vault_name
+  azuread_client_secret_name = azurerm_key_vault_secret.this.name
 
   acr_identity_client_id = module.acr.user_assigned_identity_client_id
   acr_identity_id        = module.acr.user_assigned_identity_id

--- a/variables.tf
+++ b/variables.tf
@@ -53,8 +53,13 @@ variable "azuread_client_id" {
   type        = string
 }
 
-variable "azuread_client_secret_setting" {
-  description = "The value of the App Setting that contains the client secret of the Client."
+variable "azuread_client_key_vault_name" {
+  description = "The name of the Key Vault where the Client Secret is stored."
+  type        = string
+}
+
+variable "azuread_client_secret_name" {
+  description = "The name of the Key Vault Secret containing the Client Secret."
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -53,12 +53,12 @@ variable "azuread_client_id" {
   type        = string
 }
 
-variable "azuread_client_key_vault_name" {
+variable "azuread_key_vault_name" {
   description = "The name of the Key Vault where the Client Secret is stored."
   type        = string
 }
 
-variable "azuread_client_secret_name" {
+variable "azuread_key_vault_secret_name" {
   description = "The name of the Key Vault Secret containing the Client Secret."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,12 +53,12 @@ variable "azuread_client_id" {
   type        = string
 }
 
-variable "azuread_key_vault_name" {
+variable "azuread_client_vault_name" {
   description = "The name of the Key Vault where the Client Secret is stored."
   type        = string
 }
 
-variable "azuread_key_vault_secret_name" {
+variable "azuread_client_secret_name" {
   description = "The name of the Key Vault Secret containing the Client Secret."
   type        = string
 }


### PR DESCRIPTION
Automatically reference key vault secret for client secret instead of expecting user to construct key vault reference string.