### PR TITLE
feat!: remove service plan resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ No modules.
 | [azurerm_app_service_custom_hostname_binding.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_custom_hostname_binding) | resource |
 | [azurerm_app_service_managed_certificate.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_managed_certificate) | resource |
 | [azurerm_linux_web_app.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app) | resource |
-| [azurerm_service_plan.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |
 
 ## Inputs
 
@@ -132,8 +131,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_service_hostnames"></a> [app\_service\_hostnames](#input\_app\_service\_hostnames) | A list of custom hostnames to use for the App Service. | `list(string)` | `[]` | no |
 | <a name="input_app_service_name"></a> [app\_service\_name](#input\_app\_service\_name) | A custom name for the App Service. | `string` | `null` | no |
-| <a name="input_app_service_plan_name"></a> [app\_service\_plan\_name](#input\_app\_service\_plan\_name) | A custom name for the App Service Plan. | `string` | `null` | no |
-| <a name="input_app_service_plan_sku_name"></a> [app\_service\_plan\_sku\_name](#input\_app\_service\_plan\_sku\_name) | The SKU name for the App Service Plan. | `string` | `"B1"` | no |
 | <a name="input_app_service_settings"></a> [app\_service\_settings](#input\_app\_service\_settings) | A mapping of settings for the App Service. | `map(string)` | `{}` | no |
 | <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |
 | <a name="input_azuread_client_id"></a> [azuread\_client\_id](#input\_azuread\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
@@ -144,6 +141,7 @@ No modules.
 | <a name="input_managed_identity_client_id"></a> [managed\_identity\_client\_id](#input\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | n/a | yes |
 | <a name="input_managed_identity_id"></a> [managed\_identity\_id](#input\_managed\_identity\_id) | The ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group in which to create the resources. | `string` | n/a | yes |
+| <a name="input_service_plan_id"></a> [service\_plan\_id](#input\_service\_plan\_id) | The ID of the App Service Plan that this App Service will be created in. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -154,6 +152,4 @@ No modules.
 | <a name="output_app_service_identity_principal_id"></a> [app\_service\_identity\_principal\_id](#output\_app\_service\_identity\_principal\_id) | The principal ID of the App Service Identity. |
 | <a name="output_app_service_identity_tenant_id"></a> [app\_service\_identity\_tenant\_id](#output\_app\_service\_identity\_tenant\_id) | The tenant ID of the App Service Identity. |
 | <a name="output_app_service_name"></a> [app\_service\_name](#output\_app\_service\_name) | The name of the App Service. |
-| <a name="output_app_service_plan_id"></a> [app\_service\_plan\_id](#output\_app\_service\_plan\_id) | The ID of the App Service Plan. |
-| <a name="output_app_service_plan_name"></a> [app\_service\_plan\_name](#output\_app\_service\_plan\_name) | The name of the App Service Plan. |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ module "acr" {
   resource_group_name = azurerm_resource_group.example.name
 }
 
+resource "azurerm_service_plan" "example" {
+  name                = "plan-${local.application}-${local.environment}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  os_type             = "Linux"
+  sku_name            = "B1"
+}
+
 module "web_app" {
   source = "github.com/equinor/terraform-azurerm-web-app"
 
@@ -56,6 +64,8 @@ module "web_app" {
 
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
+
+  service_plan_id = azurerm_service_plan.example.id
 
   azuread_client_id = "6b5fbe59-9c49-488f-959f-82cada7abf14"
   key_vault_name    = module.vault.key_vault_name

--- a/main.tf
+++ b/main.tf
@@ -2,21 +2,11 @@ locals {
   tags = merge({ application = var.application, environment = var.environment }, var.tags)
 }
 
-resource "azurerm_service_plan" "this" {
-  name                = coalesce(var.app_service_plan_name, "plan-${var.application}-${var.environment}")
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  os_type             = "Linux"
-  sku_name            = var.app_service_plan_sku_name
-
-  tags = local.tags
-}
-
 resource "azurerm_linux_web_app" "this" {
   name                = coalesce(var.app_service_name, "app-${var.application}-${var.environment}")
   location            = var.location
   resource_group_name = var.resource_group_name
-  service_plan_id     = azurerm_service_plan.this.id
+  service_plan_id     = var.service_plan_id
 
   https_only = true
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,3 @@
-output "app_service_plan_id" {
-  description = "The ID of the App Service Plan."
-  value       = azurerm_service_plan.this.id
-}
-
-output "app_service_plan_name" {
-  description = "The name of the App Service Plan."
-  value       = azurerm_service_plan.this.name
-}
-
 output "app_service_id" {
   description = "The ID of the App Service."
   value       = azurerm_linux_web_app.this.id

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -57,6 +57,14 @@ module "acr" {
   managed_identity_operators = [data.azurerm_client_config.current.object_id]
 }
 
+resource "azurerm_service_plan" "this" {
+  name                = "plan-${local.application}-${local.environment}"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  os_type             = "Linux"
+  sku_name            = "B1"
+}
+
 module "web_app" {
   source = "../.."
 
@@ -65,6 +73,8 @@ module "web_app" {
 
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
+
+  service_plan_id = azurerm_service_plan.this.id
 
   azuread_client_id     = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
   key_vault_name        = module.vault.key_vault_name

--- a/variables.tf
+++ b/variables.tf
@@ -8,12 +8,6 @@ variable "environment" {
   type        = string
 }
 
-variable "app_service_plan_name" {
-  description = "A custom name for the App Service Plan."
-  type        = string
-  default     = null
-}
-
 variable "location" {
   description = "The supported Azure location where the resources exist."
   type        = string
@@ -24,10 +18,9 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "app_service_plan_sku_name" {
-  description = "The SKU name for the App Service Plan."
+variable "service_plan_id" {
+  description = "The ID of the App Service Plan that this App Service will be created in."
   type        = string
-  default     = "B1"
 }
 
 variable "tags" {


### PR DESCRIPTION
BREAKING CHANGE:

Removed resource `azurerm_service_plan.this`. We do not always want to create a new service plan, sometimes we want to use a single service plan for multiple web apps. Thus, this should be created outside of the module instead.