### PR TITLE
feat!: simplify auth settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aad_client_id"></a> [aad\_client\_id](#input\_aad\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
-| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. | `string` | `"ACTIVE_DIRECTORY_AUTHENTICATION_SECRET"` | no |
+| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. | `string` | `"AAD_CLIENT_SECRET"` | no |
 | <a name="input_app_service_hostnames"></a> [app\_service\_hostnames](#input\_app\_service\_hostnames) | A list of custom hostnames to use for the App Service. | `list(string)` | `[]` | no |
 | <a name="input_app_service_name"></a> [app\_service\_name](#input\_app\_service\_name) | A custom name for the App Service. | `string` | `null` | no |
 | <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -129,14 +129,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aad_client_id"></a> [aad\_client\_id](#input\_aad\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
+| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. | `string` | `"ACTIVE_DIRECTORY_AUTHENTICATION_SECRET"` | no |
 | <a name="input_app_service_hostnames"></a> [app\_service\_hostnames](#input\_app\_service\_hostnames) | A list of custom hostnames to use for the App Service. | `list(string)` | `[]` | no |
 | <a name="input_app_service_name"></a> [app\_service\_name](#input\_app\_service\_name) | A custom name for the App Service. | `string` | `null` | no |
-| <a name="input_app_service_settings"></a> [app\_service\_settings](#input\_app\_service\_settings) | A mapping of settings for the App Service. | `map(string)` | `{}` | no |
 | <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |
-| <a name="input_azuread_client_id"></a> [azuread\_client\_id](#input\_azuread\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment to create the resources for. | `string` | n/a | yes |
-| <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name) | The name of the Key Vault where the App Registration client secret is stored. | `string` | n/a | yes |
-| <a name="input_key_vault_secret_name"></a> [key\_vault\_secret\_name](#input\_key\_vault\_secret\_name) | The name of the Key Vault Secret containing the App Registration client secret. | `string` | `"ClientSecret"` | no |
 | <a name="input_location"></a> [location](#input\_location) | The supported Azure location where the resources exist. | `string` | n/a | yes |
 | <a name="input_managed_identity_client_id"></a> [managed\_identity\_client\_id](#input\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | n/a | yes |
 | <a name="input_managed_identity_id"></a> [managed\_identity\_id](#input\_managed\_identity\_id) | The ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | n/a | yes |
@@ -148,6 +146,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#output\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. |
 | <a name="output_app_service_id"></a> [app\_service\_id](#output\_app\_service\_id) | The ID of the App Service. |
 | <a name="output_app_service_identity_principal_id"></a> [app\_service\_identity\_principal\_id](#output\_app\_service\_identity\_principal\_id) | The principal ID of the App Service Identity. |
 | <a name="output_app_service_identity_tenant_id"></a> [app\_service\_identity\_tenant\_id](#output\_app\_service\_identity\_tenant\_id) | The tenant ID of the App Service Identity. |

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,8 @@ resource "azurerm_linux_web_app" "this" {
 
   https_only = true
 
-  app_settings = merge({ ACTIVE_DIRECTORY_AUTHENTICATION_SECRET = "@Microsoft.KeyVault(VaultName=${var.key_vault_name};SecretName=${var.key_vault_secret_name})" }, var.app_service_settings)
+  # App settings should be configured during deployment
+  app_settings = null
 
   tags = local.tags
 
@@ -20,7 +21,7 @@ resource "azurerm_linux_web_app" "this" {
 
     active_directory {
       client_id                  = var.azuread_client_id
-      client_secret_setting_name = "ACTIVE_DIRECTORY_AUTHENTICATION_SECRET"
+      client_secret_setting_name = var.azuread_client_secret_setting_name
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -20,8 +20,8 @@ resource "azurerm_linux_web_app" "this" {
     token_store_enabled = true
 
     active_directory {
-      client_id                  = var.azuread_client_id
-      client_secret_setting_name = var.azuread_client_secret_setting_name
+      client_id                  = var.aad_client_id
+      client_secret_setting_name = var.aad_client_secret_setting_name
     }
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "app_service_name" {
   value       = azurerm_linux_web_app.this.name
 }
 
+output "aad_client_secret_setting_name" {
+  description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
+  value       = azurerm_linux_web_app.this.auth_settings[0].active_directory[0].client_secret_setting_name
+}
+
 output "app_service_identity_principal_id" {
   description = "The principal ID of the App Service Identity."
   value       = azurerm_linux_web_app.this.identity[0].principal_id

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -24,44 +24,21 @@ resource "azurerm_log_analytics_workspace" "this" {
   resource_group_name = azurerm_resource_group.this.name
 }
 
-module "vault" {
-  source = "github.com/equinor/terraform-azurerm-vault?ref=v3.0.0"
-
-  application = local.application
-  environment = local.environment
-
-  location            = azurerm_resource_group.this.location
-  resource_group_name = azurerm_resource_group.this.name
-
-  client_secret_permissions = ["Get", "List", "Set", "Delete", "Recover", "Backup", "Restore", "Purge"]
-
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
-}
-
-resource "azurerm_key_vault_secret" "this" {
-  name         = "ClientSecret"
-  value        = "my-secret"
-  key_vault_id = module.vault.key_vault_id
-}
-
 module "acr" {
   source = "github.com/equinor/terraform-azurerm-acr?ref=v2.0.0"
 
-  application = local.application
-  environment = local.environment
-
-  location            = azurerm_resource_group.this.location
-  resource_group_name = azurerm_resource_group.this.name
-
+  application                = local.application
+  environment                = local.environment
+  location                   = azurerm_resource_group.this.location
+  resource_group_name        = azurerm_resource_group.this.name
   managed_identity_operators = [data.azurerm_client_config.current.object_id]
 }
 
 module "app_service_plan" {
   source = "../../modules/service-plan"
 
-  application = local.application
-  environment = local.environment
-
+  application         = local.application
+  environment         = local.environment
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 }
@@ -69,26 +46,12 @@ module "app_service_plan" {
 module "web_app" {
   source = "../.."
 
-  application = local.application
-  environment = local.environment
-
-  location            = azurerm_resource_group.this.location
-  resource_group_name = azurerm_resource_group.this.name
-
-  service_plan_id = module.app_service_plan.service_plan_id
-
-  azuread_client_id     = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
-  key_vault_name        = module.vault.key_vault_name
-  key_vault_secret_name = azurerm_key_vault_secret.this.name
-
+  application                = local.application
+  environment                = local.environment
+  location                   = azurerm_resource_group.this.location
+  resource_group_name        = azurerm_resource_group.this.name
+  service_plan_id            = module.app_service_plan.service_plan_id
+  aad_client_id              = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
   managed_identity_client_id = module.acr.managed_identity_client_id
   managed_identity_id        = module.acr.managed_identity_id
-}
-
-resource "azurerm_key_vault_access_policy" "this" {
-  key_vault_id = module.vault.key_vault_id
-  tenant_id    = module.web_app.app_service_identity_tenant_id
-  object_id    = module.web_app.app_service_identity_principal_id
-
-  secret_permissions = ["Get"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,12 +35,12 @@ variable "app_service_name" {
   default     = null
 }
 
-variable "azuread_client_id" {
+variable "aad_client_id" {
   description = "The client ID of the App Registration to use for Azure AD authentication."
   type        = string
 }
 
-variable "azuread_client_secret_setting_name" {
+variable "aad_client_secret_setting_name" {
   description = "The name of the app setting that contains the client secret of the App Registration."
   type        = string
   default     = "ACTIVE_DIRECTORY_AUTHENTICATION_SECRET"

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "aad_client_id" {
 }
 
 variable "aad_client_secret_setting_name" {
-  description = "The name of the app setting that contains the client secret of the App Registration."
+  description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
   type        = string
   default     = "ACTIVE_DIRECTORY_AUTHENTICATION_SECRET"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "aad_client_id" {
 variable "aad_client_secret_setting_name" {
   description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
   type        = string
-  default     = "ACTIVE_DIRECTORY_AUTHENTICATION_SECRET"
+  default     = "AAD_CLIENT_SECRET"
 }
 
 variable "managed_identity_client_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -35,26 +35,15 @@ variable "app_service_name" {
   default     = null
 }
 
-variable "app_service_settings" {
-  description = "A mapping of settings for the App Service."
-  type        = map(string)
-  default     = {}
-}
-
 variable "azuread_client_id" {
   description = "The client ID of the App Registration to use for Azure AD authentication."
   type        = string
 }
 
-variable "key_vault_name" {
-  description = "The name of the Key Vault where the App Registration client secret is stored."
+variable "azuread_client_secret_setting_name" {
+  description = "The name of the app setting that contains the client secret of the App Registration."
   type        = string
-}
-
-variable "key_vault_secret_name" {
-  description = "The name of the Key Vault Secret containing the App Registration client secret."
-  type        = string
-  default     = "ClientSecret"
+  default     = "ACTIVE_DIRECTORY_AUTHENTICATION_SECRET"
 }
 
 variable "managed_identity_client_id" {


### PR DESCRIPTION
Reduce number of input variables required to setup Azure AD authentication.

BREAKING CHANGE: variable `app_service_settings` removed

BREAKING CHANGE: variable `azuread_client_id` renamed to `aad_client_id`

BREAKING CHANGE: variable `key_vault_name` removed

BREAKING CHANGE: variable `key_vault_secret_name` removed
