### PR TITLE
feat!: create multiple apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,42 +7,30 @@ Terraform module which creates an Azure Web App.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.0.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.0.0 |
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_linux_app"></a> [linux\_app](#module\_linux\_app) | ./modules/linux-app | n/a |
 | <a name="module_service_plan"></a> [service\_plan](#module\_service\_plan) | ./modules/service-plan | n/a |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [azurerm_app_service_certificate_binding.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_certificate_binding) | resource |
-| [azurerm_app_service_custom_hostname_binding.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_custom_hostname_binding) | resource |
-| [azurerm_app_service_managed_certificate.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_managed_certificate) | resource |
-| [azurerm_linux_web_app.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app) | resource |
+No resources.
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aad_client_id"></a> [aad\_client\_id](#input\_aad\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
-| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. | `string` | `"AAD_CLIENT_SECRET"` | no |
-| <a name="input_acr_managed_identity_client_id"></a> [acr\_managed\_identity\_client\_id](#input\_acr\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | `null` | no |
-| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | The name of this Web App. | `string` | `null` | no |
-| <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should authentication be enabled for this Web App? | `bool` | `true` | no |
-| <a name="input_custom_hostnames"></a> [custom\_hostnames](#input\_custom\_hostnames) | A list of custom hostnames to bind to this Web App. | `list(string)` | `[]` | no |
+| <a name="input_apps"></a> [apps](#input\_apps) | The apps to create for this Web App service plan. | <pre>map(object({<br>    name                           = string<br>    auth_settings_enabled          = optional(bool, true)<br>    aad_client_id                  = string<br>    aad_client_secret_setting_name = optional(string, "AAD_CLIENT_SECRET")<br>    acr_managed_identity_client_id = optional(string)<br>    managed_identity_ids           = optional(list(string), [])<br>    custom_hostnames               = optional(list(string), [])<br>  }))</pre> | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
-| <a name="input_managed_identity_ids"></a> [managed\_identity\_ids](#input\_managed\_identity\_ids) | The IDs of the Managed Identities to assign to this Web App. | `list(string)` | `[]` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to create the resources in. | `string` | n/a | yes |
 | <a name="input_service_plan_name"></a> [service\_plan\_name](#input\_service\_plan\_name) | The name of this Web App service plan. | `string` | n/a | yes |
 | <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | The SKU name for this service plan. | `string` | `"B1"` | no |
@@ -52,11 +40,10 @@ Terraform module which creates an Azure Web App.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#output\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. |
-| <a name="output_app_id"></a> [app\_id](#output\_app\_id) | The ID of this Web App. |
-| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | The name of this Web App. |
-| <a name="output_identity_principal_id"></a> [identity\_principal\_id](#output\_identity\_principal\_id) | The principal ID of the system-assigned identity of this Web App. |
-| <a name="output_identity_tenant_id"></a> [identity\_tenant\_id](#output\_identity\_tenant\_id) | The tenant ID of the system-assigned identity of this Web App. |
+| <a name="output_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#output\_aad\_client\_secret\_setting\_name) | n/a |
+| <a name="output_app_ids"></a> [app\_ids](#output\_app\_ids) | A mapping of Web App IDs for this service plan. |
+| <a name="output_app_names"></a> [app\_names](#output\_app\_names) | A mapping of Web App names for this service plan. |
+| <a name="output_identity_principal_ids"></a> [identity\_principal\_ids](#output\_identity\_principal\_ids) | A mapping of system-assigned identity IDs of the created Web Apps. |
 | <a name="output_service_plan_id"></a> [service\_plan\_id](#output\_service\_plan\_id) | The ID of this Web App service plan. |
 | <a name="output_service_plan_name"></a> [service\_plan\_name](#output\_service\_plan\_name) | The name of this Web App service plan. |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apps"></a> [apps](#input\_apps) | The apps to create for this Web App service plan. | <pre>map(object({<br>    name                           = string<br>    auth_settings_enabled          = optional(bool, true)<br>    aad_client_id                  = string<br>    aad_client_secret_setting_name = optional(string, "AAD_CLIENT_SECRET")<br>    acr_managed_identity_client_id = optional(string)<br>    managed_identity_ids           = optional(list(string), [])<br>    custom_hostnames               = optional(list(string), [])<br>  }))</pre> | n/a | yes |
+| <a name="input_apps"></a> [apps](#input\_apps) | The apps to create for this Web App service plan. | <pre>map(object({<br>    name                           = string<br>    auth_settings_enabled          = optional(bool, true)<br>    aad_client_id                  = string<br>    aad_client_secret_setting_name = optional(string, "AAD_CLIENT_SECRET")<br>    acr_managed_identity_client_id = optional(string)<br>    managed_identity_ids           = optional(list(string), [])<br>    custom_hostnames               = optional(list(string), [])<br>  }))</pre> | `{}` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to create the resources in. | `string` | n/a | yes |
 | <a name="input_service_plan_name"></a> [service\_plan\_name](#input\_service\_plan\_name) | The name of this Web App service plan. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aad_client_secret_setting_names"></a> [aad\_client\_secret\_setting\_names](#output\_aad\_client\_secret\_setting\_names) | n/a |
+| <a name="output_aad_client_secret_setting_names"></a> [aad\_client\_secret\_setting\_names](#output\_aad\_client\_secret\_setting\_names) | A mapping of the app setting name where the Azure AD client secret must be stored for each Web App. |
 | <a name="output_app_ids"></a> [app\_ids](#output\_app\_ids) | A mapping of Web App IDs for this service plan. |
 | <a name="output_app_names"></a> [app\_names](#output\_app\_names) | A mapping of Web App names for this service plan. |
 | <a name="output_identity_principal_ids"></a> [identity\_principal\_ids](#output\_identity\_principal\_ids) | A mapping of system-assigned identity IDs of the created Web Apps. |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#output\_aad\_client\_secret\_setting\_name) | n/a |
+| <a name="output_aad_client_secret_setting_names"></a> [aad\_client\_secret\_setting\_names](#output\_aad\_client\_secret\_setting\_names) | n/a |
 | <a name="output_app_ids"></a> [app\_ids](#output\_app\_ids) | A mapping of Web App IDs for this service plan. |
 | <a name="output_app_names"></a> [app\_names](#output\_app\_names) | A mapping of Web App names for this service plan. |
 | <a name="output_identity_principal_ids"></a> [identity\_principal\_ids](#output\_identity\_principal\_ids) | A mapping of system-assigned identity IDs of the created Web Apps. |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,6 @@
 # Basic example
 
-Terraform configuration which creates an Azure Web App with the following features:
+Terraform configuration which creates two Azure Linux Web Apps with the following features:
 
 - Basic SKU (B1)
 - HTTPS only

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -24,9 +24,19 @@ module "log_analytics" {
 module "web_app" {
   source = "../.."
 
-  app_name            = "app-${random_id.this.hex}"
+  service_plan_name   = "plan-${random_id.this.hex}"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
-  service_plan_name   = "plan-${random_id.this.hex}"
-  aad_client_id       = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
+
+  apps = {
+    "api" = {
+      name          = "app-${random_id.this.hex}-api"
+      aad_client_id = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
+    }
+
+    "web" = {
+      name          = "app-${random_id.this.hex}-web"
+      aad_client_id = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
+    }
+  }
 }

--- a/examples/container-app/README.md
+++ b/examples/container-app/README.md
@@ -1,6 +1,6 @@
 # Container application example
 
-Terraform configuration which creates an Azure Web App for Containers with the following features:
+Terraform configuration which creates two Azure Web Apps for Containers with the following features:
 
 - Basic SKU (B1)
 - HTTPS only

--- a/examples/container-app/main.tf
+++ b/examples/container-app/main.tf
@@ -34,11 +34,23 @@ module "acr" {
 module "web_app" {
   source = "../.."
 
-  app_name                       = "app-${random_id.this.hex}"
-  location                       = azurerm_resource_group.this.location
-  resource_group_name            = azurerm_resource_group.this.name
-  service_plan_name              = "plan-${random_id.this.hex}"
-  aad_client_id                  = "fe94e238-69a9-4633-94d0-c7f56dea76e8"
-  acr_managed_identity_client_id = module.acr.managed_identity_client_id
-  managed_identity_ids           = [module.acr.managed_identity_id]
+  service_plan_name   = "plan-${random_id.this.hex}"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  apps = {
+    "api" = {
+      name                           = "app-${random_id.this.hex}-api"
+      aad_client_id                  = "8487f986-ba7b-47df-bbd8-b657a6d737e5"
+      acr_managed_identity_client_id = module.acr.managed_identity_client_id
+      managed_identity_ids           = [module.acr.managed_identity_id]
+    }
+
+    "web" = {
+      name                           = "app-${random_id.this.hex}-web"
+      aad_client_id                  = "8487f986-ba7b-47df-bbd8-b657a6d737e5"
+      acr_managed_identity_client_id = module.acr.managed_identity_client_id
+      managed_identity_ids           = [module.acr.managed_identity_id]
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,61 +9,19 @@ module "service_plan" {
   tags = var.tags
 }
 
-resource "azurerm_linux_web_app" "this" {
-  name                = var.app_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  service_plan_id     = module.service_plan.id
+module "linux_app" {
+  for_each = var.apps
 
-  https_only = true
+  source = "./modules/linux-app"
 
-  # App settings should be configured during deployment
-  app_settings = null
-
-  tags = var.tags
-
-  auth_settings {
-    enabled             = var.auth_settings_enabled
-    token_store_enabled = true
-
-    active_directory {
-      client_id                  = var.aad_client_id
-      client_secret_setting_name = var.aad_client_secret_setting_name
-    }
-  }
-
-  site_config {
-    container_registry_use_managed_identity       = var.acr_managed_identity_client_id != null ? true : false
-    container_registry_managed_identity_client_id = var.acr_managed_identity_client_id
-  }
-
-  identity {
-    type         = length(var.managed_identity_ids) > 0 ? "SystemAssigned, UserAssigned" : "SystemAssigned"
-    identity_ids = var.managed_identity_ids
-  }
-}
-
-# Create a custom hostname binding for each custom hostname
-resource "azurerm_app_service_custom_hostname_binding" "this" {
-  for_each = toset(var.custom_hostnames)
-
-  hostname            = each.value
-  app_service_name    = azurerm_linux_web_app.this.name
-  resource_group_name = var.resource_group_name
-}
-
-# Create a managed certificate for each custom hostname binding
-resource "azurerm_app_service_managed_certificate" "this" {
-  for_each = azurerm_app_service_custom_hostname_binding.this
-
-  custom_hostname_binding_id = each.value.id
-}
-
-# Create a certificate binding for each managed certificate
-resource "azurerm_app_service_certificate_binding" "this" {
-  for_each = azurerm_app_service_managed_certificate.this
-
-  hostname_binding_id = each.value.custom_hostname_binding_id
-  certificate_id      = each.value.id
-  ssl_state           = "SniEnabled"
+  name                           = each.value.name
+  resource_group_name            = var.resource_group_name
+  location                       = var.location
+  service_plan_id                = module.service_plan.id
+  auth_settings_enabled          = each.value.auth_settings_enabled
+  aad_client_id                  = each.value.aad_client_id
+  aad_client_secret_setting_name = each.value.aad_client_secret_setting_name
+  acr_managed_identity_client_id = each.value.acr_managed_identity_client_id
+  managed_identity_ids           = each.value.managed_identity_ids
+  custom_hostnames               = each.value.custom_hostnames
 }

--- a/modules/linux-app/README.md
+++ b/modules/linux-app/README.md
@@ -1,3 +1,7 @@
+# Azure Linux Web App Terraform sub-module
+
+Terraform sub-module which creates an Azure Linux Web App.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/linux-app/README.md
+++ b/modules/linux-app/README.md
@@ -1,0 +1,50 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_app_service_certificate_binding.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_certificate_binding) | resource |
+| [azurerm_app_service_custom_hostname_binding.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_custom_hostname_binding) | resource |
+| [azurerm_app_service_managed_certificate.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_managed_certificate) | resource |
+| [azurerm_linux_web_app.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aad_client_id"></a> [aad\_client\_id](#input\_aad\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
+| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. | `string` | `"AAD_CLIENT_SECRET"` | no |
+| <a name="input_acr_managed_identity_client_id"></a> [acr\_managed\_identity\_client\_id](#input\_acr\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | `null` | no |
+| <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should authentication be enabled for this Linux Web App? | `bool` | `true` | no |
+| <a name="input_custom_hostnames"></a> [custom\_hostnames](#input\_custom\_hostnames) | A list of custom hostnames to bind to this Linux Web App. | `list(string)` | `[]` | no |
+| <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
+| <a name="input_managed_identity_ids"></a> [managed\_identity\_ids](#input\_managed\_identity\_ids) | The IDs of the Managed Identities to assign to this Linux Web App. | `list(string)` | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of this Linux Web App. | `string` | `null` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to create the resources in. | `string` | n/a | yes |
+| <a name="input_service_plan_id"></a> [service\_plan\_id](#input\_service\_plan\_id) | The ID of the service plan to create this Linux Web App for. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#output\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of this Linux Web App. |
+| <a name="output_identity_principal_id"></a> [identity\_principal\_id](#output\_identity\_principal\_id) | The principal ID of the system-assigned identity of this Linux Web App. |
+| <a name="output_identity_tenant_id"></a> [identity\_tenant\_id](#output\_identity\_tenant\_id) | The tenant ID of the system-assigned identity of this Linux Web App. |
+| <a name="output_name"></a> [name](#output\_name) | The name of this Linux Web App. |
+<!-- END_TF_DOCS -->

--- a/modules/linux-app/README.md
+++ b/modules/linux-app/README.md
@@ -27,7 +27,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aad_client_id"></a> [aad\_client\_id](#input\_aad\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
-| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. | `string` | `"AAD_CLIENT_SECRET"` | no |
+| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting where the client secret of the App Registration to use for Azure AD authentication must be stored. | `string` | `"AAD_CLIENT_SECRET"` | no |
 | <a name="input_acr_managed_identity_client_id"></a> [acr\_managed\_identity\_client\_id](#input\_acr\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | `null` | no |
 | <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should authentication be enabled for this Linux Web App? | `bool` | `true` | no |
 | <a name="input_custom_hostnames"></a> [custom\_hostnames](#input\_custom\_hostnames) | A list of custom hostnames to bind to this Linux Web App. | `list(string)` | `[]` | no |

--- a/modules/linux-app/main.tf
+++ b/modules/linux-app/main.tf
@@ -1,0 +1,58 @@
+resource "azurerm_linux_web_app" "this" {
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  service_plan_id     = var.service_plan_id
+
+  https_only = true
+
+  # App settings should be configured during deployment
+  app_settings = null
+
+  tags = var.tags
+
+  auth_settings {
+    enabled             = var.auth_settings_enabled
+    token_store_enabled = true
+
+    active_directory {
+      client_id                  = var.aad_client_id
+      client_secret_setting_name = var.aad_client_secret_setting_name
+    }
+  }
+
+  site_config {
+    container_registry_use_managed_identity       = var.acr_managed_identity_client_id != null ? true : false
+    container_registry_managed_identity_client_id = var.acr_managed_identity_client_id
+  }
+
+  identity {
+    type         = length(var.managed_identity_ids) > 0 ? "SystemAssigned, UserAssigned" : "SystemAssigned"
+    identity_ids = var.managed_identity_ids
+  }
+}
+
+# Create a custom hostname binding for each custom hostname
+resource "azurerm_app_service_custom_hostname_binding" "this" {
+  for_each = toset(var.custom_hostnames)
+
+  hostname            = each.value
+  app_service_name    = azurerm_linux_web_app.this.name
+  resource_group_name = var.resource_group_name
+}
+
+# Create a managed certificate for each custom hostname binding
+resource "azurerm_app_service_managed_certificate" "this" {
+  for_each = azurerm_app_service_custom_hostname_binding.this
+
+  custom_hostname_binding_id = each.value.id
+}
+
+# Create a certificate binding for each managed certificate
+resource "azurerm_app_service_certificate_binding" "this" {
+  for_each = azurerm_app_service_managed_certificate.this
+
+  hostname_binding_id = each.value.custom_hostname_binding_id
+  certificate_id      = each.value.id
+  ssl_state           = "SniEnabled"
+}

--- a/modules/linux-app/outputs.tf
+++ b/modules/linux-app/outputs.tf
@@ -1,0 +1,24 @@
+output "id" {
+  description = "The ID of this Linux Web App."
+  value       = azurerm_linux_web_app.this.id
+}
+
+output "name" {
+  description = "The name of this Linux Web App."
+  value       = azurerm_linux_web_app.this.name
+}
+
+output "aad_client_secret_setting_name" {
+  description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
+  value       = azurerm_linux_web_app.this.auth_settings[0].active_directory[0].client_secret_setting_name
+}
+
+output "identity_principal_id" {
+  description = "The principal ID of the system-assigned identity of this Linux Web App."
+  value       = azurerm_linux_web_app.this.identity[0].principal_id
+}
+
+output "identity_tenant_id" {
+  description = "The tenant ID of the system-assigned identity of this Linux Web App."
+  value       = azurerm_linux_web_app.this.identity[0].tenant_id
+}

--- a/modules/linux-app/variables.tf
+++ b/modules/linux-app/variables.tf
@@ -1,0 +1,61 @@
+variable "name" {
+  description = "The name of this Linux Web App."
+  type        = string
+  default     = null
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group to create the resources in."
+  type        = string
+}
+
+variable "location" {
+  description = "The location to create the resources in."
+  type        = string
+}
+
+variable "service_plan_id" {
+  description = "The ID of the service plan to create this Linux Web App for."
+  type        = string
+}
+
+variable "auth_settings_enabled" {
+  description = "Should authentication be enabled for this Linux Web App?"
+  type        = bool
+  default     = true
+}
+
+variable "aad_client_id" {
+  description = "The client ID of the App Registration to use for Azure AD authentication."
+  type        = string
+}
+
+variable "aad_client_secret_setting_name" {
+  description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
+  type        = string
+  default     = "AAD_CLIENT_SECRET"
+}
+
+variable "acr_managed_identity_client_id" {
+  description = "The client ID of the Managed Identity that will be used to pull from the Container Registry."
+  type        = string
+  default     = null
+}
+
+variable "managed_identity_ids" {
+  description = "The IDs of the Managed Identities to assign to this Linux Web App."
+  type        = list(string)
+  default     = []
+}
+
+variable "custom_hostnames" {
+  description = "A list of custom hostnames to bind to this Linux Web App."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/linux-app/variables.tf
+++ b/modules/linux-app/variables.tf
@@ -31,7 +31,7 @@ variable "aad_client_id" {
 }
 
 variable "aad_client_secret_setting_name" {
-  description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
+  description = "The name of the app setting where the client secret of the App Registration to use for Azure AD authentication must be stored."
   type        = string
   default     = "AAD_CLIENT_SECRET"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "app_names" {
 }
 
 output "aad_client_secret_setting_names" {
-  description = "" # TODO: Write a description.
+  description = "A mapping of the app setting name where the Azure AD client secret must be stored for each Web App."
   value = {
     for k, v in module.linux_app : k => v.aad_client_secret_setting_name
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,7 +22,7 @@ output "app_names" {
   }
 }
 
-output "aad_client_secret_setting_name" {
+output "aad_client_secret_setting_names" {
   description = "" # TODO: Write a description.
   value = {
     for k, v in module.linux_app : k => v.aad_client_secret_setting_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,3 @@
-output "app_id" {
-  description = "The ID of this Web App."
-  value       = azurerm_linux_web_app.this.id
-}
-
-output "app_name" {
-  description = "The name of this Web App."
-  value       = azurerm_linux_web_app.this.name
-}
-
 output "service_plan_id" {
   description = "The ID of this Web App service plan."
   value       = module.service_plan.id
@@ -18,17 +8,30 @@ output "service_plan_name" {
   value       = module.service_plan.name
 }
 
+output "app_ids" {
+  description = "A mapping of Web App IDs for this service plan."
+  value = {
+    for k, v in module.linux_app : k => v.id
+  }
+}
+
+output "app_names" {
+  description = "A mapping of Web App names for this service plan."
+  value = {
+    for k, v in module.linux_app : k => v.name
+  }
+}
+
 output "aad_client_secret_setting_name" {
-  description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
-  value       = azurerm_linux_web_app.this.auth_settings[0].active_directory[0].client_secret_setting_name
+  description = "" # TODO: Write a description.
+  value = {
+    for k, v in module.linux_app : k => v.aad_client_secret_setting_name
+  }
 }
 
-output "identity_principal_id" {
-  description = "The principal ID of the system-assigned identity of this Web App."
-  value       = azurerm_linux_web_app.this.identity[0].principal_id
-}
-
-output "identity_tenant_id" {
-  description = "The tenant ID of the system-assigned identity of this Web App."
-  value       = azurerm_linux_web_app.this.identity[0].tenant_id
+output "identity_principal_ids" {
+  description = "A mapping of system-assigned identity IDs of the created Web Apps."
+  value = {
+    for k, v in module.linux_app : k => v.identity_principal_id
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,7 @@ variable "apps" {
     managed_identity_ids           = optional(list(string), [])
     custom_hostnames               = optional(list(string), [])
   }))
+  default = {}
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,6 @@
-variable "app_name" {
-  description = "The name of this Web App."
+variable "service_plan_name" {
+  description = "The name of this Web App service plan."
   type        = string
-  default     = null
 }
 
 variable "resource_group_name" {
@@ -14,50 +13,23 @@ variable "location" {
   type        = string
 }
 
-variable "service_plan_name" {
-  description = "The name of this Web App service plan."
-  type        = string
-}
-
 variable "sku_name" {
   description = "The SKU name for this service plan."
   type        = string
   default     = "B1"
 }
 
-variable "auth_settings_enabled" {
-  description = "Should authentication be enabled for this Web App?"
-  type        = bool
-  default     = true
-}
-
-variable "aad_client_id" {
-  description = "The client ID of the App Registration to use for Azure AD authentication."
-  type        = string
-}
-
-variable "aad_client_secret_setting_name" {
-  description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
-  type        = string
-  default     = "AAD_CLIENT_SECRET"
-}
-
-variable "acr_managed_identity_client_id" {
-  description = "The client ID of the Managed Identity that will be used to pull from the Container Registry."
-  type        = string
-  default     = null
-}
-
-variable "managed_identity_ids" {
-  description = "The IDs of the Managed Identities to assign to this Web App."
-  type        = list(string)
-  default     = []
-}
-
-variable "custom_hostnames" {
-  description = "A list of custom hostnames to bind to this Web App."
-  type        = list(string)
-  default     = []
+variable "apps" {
+  description = "The apps to create for this Web App service plan."
+  type = map(object({
+    name                           = string
+    auth_settings_enabled          = optional(bool, true)
+    aad_client_id                  = string
+    aad_client_secret_setting_name = optional(string, "AAD_CLIENT_SECRET")
+    acr_managed_identity_client_id = optional(string)
+    managed_identity_ids           = optional(list(string), [])
+    custom_hostnames               = optional(list(string), [])
+  }))
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     azurerm = {


### PR DESCRIPTION
Pass a map of apps to create on the service plan.

BREAKING CHANGE: remove variable `app_name`

BREAKING CHANGE: remove variable `auth_settings_enabled`

BREAKING CHANGE: remove variable `aad_client_id`

BREAKING CHANGE: remove variable `aad_client_secret_setting_name`

BREAKING CHANGE: remove variable `acr_managed_identity_client_id`

BREAKING CHANGE: remove variable `managed_identity_ids`

BREAKING CHANGE: remove variable `custom_hostnames`

BREAKING CHANGE: remove output `app_id`

BREAKING CHANGE: remove output `app_name`

BREAKING CHANGE: remove output `aad_client_secret_setting_name`

BREAKING CHANGE: remove output `identity_principal_id`

BREAKING CHANGE: remove output `identity_tenant_id`
