### PR TITLE
chore(examples): set feature flag in provider config

### DIFF
--- a/examples/container-app/main.tf
+++ b/examples/container-app/main.tf
@@ -1,5 +1,11 @@
+# Set feature flag within the `features` block when configuring the provider
+# to enable Terraform to delete resource groups still containing resources. 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "random_id" "this" {

--- a/examples/container-app/main.tf
+++ b/examples/container-app/main.tf
@@ -1,6 +1,8 @@
 provider "azurerm" {
   features {
     resource_group {
+      # Azure sometimes automatically creates a "default" app service plan that is not managed by Terraform,
+      # preventing Terraform from destroying the resource group.
       prevent_deletion_if_contains_resources = false
     }
   }

--- a/examples/container-app/main.tf
+++ b/examples/container-app/main.tf
@@ -1,5 +1,3 @@
-# Set feature flag within the `features` block when configuring the provider
-# to enable Terraform to delete resource groups still containing resources. 
 provider "azurerm" {
   features {
     resource_group {

--- a/examples/linux-app/main.tf
+++ b/examples/linux-app/main.tf
@@ -1,5 +1,11 @@
+# Set feature flag within the `features` block when configuring the provider
+# to enable Terraform to delete resource groups still containing resources. 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "random_id" "this" {

--- a/examples/linux-app/main.tf
+++ b/examples/linux-app/main.tf
@@ -1,6 +1,8 @@
 provider "azurerm" {
   features {
     resource_group {
+      # Azure sometimes automatically creates a "default" app service plan that is not managed by Terraform,
+      # preventing Terraform from destroying the resource group.
       prevent_deletion_if_contains_resources = false
     }
   }

--- a/examples/linux-app/main.tf
+++ b/examples/linux-app/main.tf
@@ -1,5 +1,3 @@
-# Set feature flag within the `features` block when configuring the provider
-# to enable Terraform to delete resource groups still containing resources. 
 provider "azurerm" {
   features {
     resource_group {

--- a/examples/windows-app/main.tf
+++ b/examples/windows-app/main.tf
@@ -3,6 +3,8 @@
 provider "azurerm" {
   features {
     resource_group {
+      # Azure sometimes automatically creates a "default" app service plan that is not managed by Terraform,
+      # preventing Terraform from destroying the resource group.
       prevent_deletion_if_contains_resources = false
     }
   }

--- a/examples/windows-app/main.tf
+++ b/examples/windows-app/main.tf
@@ -1,5 +1,11 @@
+# Set feature flag within the `features` block when configuring the provider
+# to enable Terraform to delete resource groups still containing resources. 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "random_id" "this" {

--- a/examples/windows-app/main.tf
+++ b/examples/windows-app/main.tf
@@ -1,5 +1,3 @@
-# Set feature flag within the `features` block when configuring the provider
-# to enable Terraform to delete resource groups still containing resources. 
 provider "azurerm" {
   features {
     resource_group {


### PR DESCRIPTION
Set feature flag within the `features` block when configuring the provider to enable Terraform to delete resource groups still containing resources. 