### PR TITLE
fix: make app inputs not nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apps"></a> [apps](#input\_apps) | The apps to create for this Web App service plan. | <pre>map(object({<br>    name                           = string<br>    auth_settings_enabled          = optional(bool, true)<br>    aad_client_id                  = string<br>    aad_client_secret_setting_name = optional(string, "AAD_CLIENT_SECRET")<br>    acr_managed_identity_client_id = optional(string)<br>    managed_identity_ids           = optional(list(string), [])<br>    custom_hostnames               = optional(list(string), [])<br>  }))</pre> | `{}` | no |
+| <a name="input_apps"></a> [apps](#input\_apps) | A map of identifier => Linux/Windows Web App objects | <pre>map(object({<br>    name                           = string<br>    auth_settings_enabled          = optional(bool)<br>    aad_client_id                  = string<br>    aad_client_secret_setting_name = optional(string)<br>    acr_managed_identity_client_id = optional(string)<br>    managed_identity_ids           = optional(list(string))<br>    custom_hostnames               = optional(list(string))<br>  }))</pre> | `{}` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
 | <a name="input_os_type"></a> [os\_type](#input\_os\_type) | The OS type for the apps to be hosted on this Web App service plan. | `string` | `"Linux"` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to create the resources in. | `string` | n/a | yes |

--- a/modules/linux-app/variables.tf
+++ b/modules/linux-app/variables.tf
@@ -23,6 +23,7 @@ variable "auth_settings_enabled" {
   description = "Should authentication be enabled for this Linux Web App?"
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "aad_client_id" {
@@ -34,6 +35,7 @@ variable "aad_client_secret_setting_name" {
   description = "The name of the app setting where the client secret of the App Registration to use for Azure AD authentication must be stored."
   type        = string
   default     = "AAD_CLIENT_SECRET"
+  nullable    = false
 }
 
 variable "acr_managed_identity_client_id" {
@@ -46,12 +48,14 @@ variable "managed_identity_ids" {
   description = "The IDs of the Managed Identities to assign to this Linux Web App."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "custom_hostnames" {
   description = "A list of custom hostnames to bind to this Linux Web App."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "tags" {

--- a/modules/windows-app/variables.tf
+++ b/modules/windows-app/variables.tf
@@ -23,6 +23,7 @@ variable "auth_settings_enabled" {
   description = "Should authentication be enabled for this Windows Web App?"
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "aad_client_id" {
@@ -34,6 +35,7 @@ variable "aad_client_secret_setting_name" {
   description = "The name of the app setting where the client secret of the App Registration to use for Azure AD authentication must be stored."
   type        = string
   default     = "AAD_CLIENT_SECRET"
+  nullable    = false
 }
 
 variable "acr_managed_identity_client_id" {
@@ -46,12 +48,14 @@ variable "managed_identity_ids" {
   description = "The IDs of the Managed Identities to assign to this Windows Web App."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "custom_hostnames" {
   description = "A list of custom hostnames to bind to this Windows Web App."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,15 +26,15 @@ variable "sku_name" {
 }
 
 variable "apps" {
-  description = "The apps to create for this Web App service plan."
+  description = "A map of identifier => Linux/Windows Web App objects"
   type = map(object({
     name                           = string
-    auth_settings_enabled          = optional(bool, true)
+    auth_settings_enabled          = optional(bool)
     aad_client_id                  = string
-    aad_client_secret_setting_name = optional(string, "AAD_CLIENT_SECRET")
+    aad_client_secret_setting_name = optional(string)
     acr_managed_identity_client_id = optional(string)
-    managed_identity_ids           = optional(list(string), [])
-    custom_hostnames               = optional(list(string), [])
+    managed_identity_ids           = optional(list(string))
+    custom_hostnames               = optional(list(string))
   }))
   default = {}
 }


### PR DESCRIPTION
Update app inputs to not be nullable, so that if a value `null` is passed to one of these inputs, it will use the default value of the variable instead of `null`.