### PR TITLE
refactor: update variable and output descriptions

### DIFF
--- a/modules/linux-app/README.md
+++ b/modules/linux-app/README.md
@@ -31,7 +31,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aad_client_id"></a> [aad\_client\_id](#input\_aad\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
-| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting where the client secret of the App Registration to use for Azure AD authentication must be stored. | `string` | `"AAD_CLIENT_SECRET"` | no |
+| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that should contain the client secret to use for Azure AD authentication. | `string` | `"AAD_CLIENT_SECRET"` | no |
 | <a name="input_acr_managed_identity_client_id"></a> [acr\_managed\_identity\_client\_id](#input\_acr\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | `null` | no |
 | <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should authentication be enabled for this Linux Web App? | `bool` | `true` | no |
 | <a name="input_custom_hostnames"></a> [custom\_hostnames](#input\_custom\_hostnames) | A list of custom hostnames to bind to this Linux Web App. | `list(string)` | `[]` | no |
@@ -46,7 +46,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#output\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. |
+| <a name="output_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#output\_aad\_client\_secret\_setting\_name) | The name of the app setting that should contain the client secret to use for Azure AD authentication. |
 | <a name="output_id"></a> [id](#output\_id) | The ID of this Linux Web App. |
 | <a name="output_identity_principal_id"></a> [identity\_principal\_id](#output\_identity\_principal\_id) | The principal ID of the system-assigned identity of this Linux Web App. |
 | <a name="output_identity_tenant_id"></a> [identity\_tenant\_id](#output\_identity\_tenant\_id) | The tenant ID of the system-assigned identity of this Linux Web App. |

--- a/modules/linux-app/README.md
+++ b/modules/linux-app/README.md
@@ -33,7 +33,7 @@ No modules.
 | <a name="input_aad_client_id"></a> [aad\_client\_id](#input\_aad\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
 | <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that should contain the client secret to use for Azure AD authentication. | `string` | `"AAD_CLIENT_SECRET"` | no |
 | <a name="input_acr_managed_identity_client_id"></a> [acr\_managed\_identity\_client\_id](#input\_acr\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | `null` | no |
-| <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should authentication be enabled for this Linux Web App? | `bool` | `true` | no |
+| <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should the built-in authentication settings be enabled for this Linux Web App? | `bool` | `true` | no |
 | <a name="input_custom_hostnames"></a> [custom\_hostnames](#input\_custom\_hostnames) | A list of custom hostnames to bind to this Linux Web App. | `list(string)` | `[]` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
 | <a name="input_managed_identity_ids"></a> [managed\_identity\_ids](#input\_managed\_identity\_ids) | The IDs of the Managed Identities to assign to this Linux Web App. | `list(string)` | `[]` | no |

--- a/modules/linux-app/outputs.tf
+++ b/modules/linux-app/outputs.tf
@@ -9,7 +9,7 @@ output "name" {
 }
 
 output "aad_client_secret_setting_name" {
-  description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
+  description = "The name of the app setting that should contain the client secret to use for Azure AD authentication."
   value       = azurerm_linux_web_app.this.auth_settings[0].active_directory[0].client_secret_setting_name
 }
 

--- a/modules/linux-app/variables.tf
+++ b/modules/linux-app/variables.tf
@@ -32,7 +32,7 @@ variable "aad_client_id" {
 }
 
 variable "aad_client_secret_setting_name" {
-  description = "The name of the app setting where the client secret of the App Registration to use for Azure AD authentication must be stored."
+  description = "The name of the app setting that should contain the client secret to use for Azure AD authentication."
   type        = string
   default     = "AAD_CLIENT_SECRET"
   nullable    = false

--- a/modules/linux-app/variables.tf
+++ b/modules/linux-app/variables.tf
@@ -20,7 +20,7 @@ variable "service_plan_id" {
 }
 
 variable "auth_settings_enabled" {
-  description = "Should authentication be enabled for this Linux Web App?"
+  description = "Should the built-in authentication settings be enabled for this Linux Web App?"
   type        = bool
   default     = true
   nullable    = false

--- a/modules/windows-app/README.md
+++ b/modules/windows-app/README.md
@@ -31,7 +31,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aad_client_id"></a> [aad\_client\_id](#input\_aad\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
-| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting where the client secret of the App Registration to use for Azure AD authentication must be stored. | `string` | `"AAD_CLIENT_SECRET"` | no |
+| <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that should contain the client secret to use for Azure AD authentication. | `string` | `"AAD_CLIENT_SECRET"` | no |
 | <a name="input_acr_managed_identity_client_id"></a> [acr\_managed\_identity\_client\_id](#input\_acr\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | `null` | no |
 | <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should authentication be enabled for this Windows Web App? | `bool` | `true` | no |
 | <a name="input_custom_hostnames"></a> [custom\_hostnames](#input\_custom\_hostnames) | A list of custom hostnames to bind to this Windows Web App. | `list(string)` | `[]` | no |
@@ -46,7 +46,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#output\_aad\_client\_secret\_setting\_name) | The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication. |
+| <a name="output_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#output\_aad\_client\_secret\_setting\_name) | The name of the app setting that should contain the client secret to use for Azure AD authentication. |
 | <a name="output_id"></a> [id](#output\_id) | The ID of this Windows Web App. |
 | <a name="output_identity_principal_id"></a> [identity\_principal\_id](#output\_identity\_principal\_id) | The principal ID of the system-assigned identity of this Windows Web App. |
 | <a name="output_identity_tenant_id"></a> [identity\_tenant\_id](#output\_identity\_tenant\_id) | The tenant ID of the system-assigned identity of this Windows Web App. |

--- a/modules/windows-app/README.md
+++ b/modules/windows-app/README.md
@@ -33,7 +33,7 @@ No modules.
 | <a name="input_aad_client_id"></a> [aad\_client\_id](#input\_aad\_client\_id) | The client ID of the App Registration to use for Azure AD authentication. | `string` | n/a | yes |
 | <a name="input_aad_client_secret_setting_name"></a> [aad\_client\_secret\_setting\_name](#input\_aad\_client\_secret\_setting\_name) | The name of the app setting that should contain the client secret to use for Azure AD authentication. | `string` | `"AAD_CLIENT_SECRET"` | no |
 | <a name="input_acr_managed_identity_client_id"></a> [acr\_managed\_identity\_client\_id](#input\_acr\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | `null` | no |
-| <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should authentication be enabled for this Windows Web App? | `bool` | `true` | no |
+| <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should the built-in authentication settings be enabled for this Windows Web App? | `bool` | `true` | no |
 | <a name="input_custom_hostnames"></a> [custom\_hostnames](#input\_custom\_hostnames) | A list of custom hostnames to bind to this Windows Web App. | `list(string)` | `[]` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
 | <a name="input_managed_identity_ids"></a> [managed\_identity\_ids](#input\_managed\_identity\_ids) | The IDs of the Managed Identities to assign to this Windows Web App. | `list(string)` | `[]` | no |

--- a/modules/windows-app/outputs.tf
+++ b/modules/windows-app/outputs.tf
@@ -9,7 +9,7 @@ output "name" {
 }
 
 output "aad_client_secret_setting_name" {
-  description = "The name of the app setting that contains the client secret of the App Registration to use for Azure AD authentication."
+  description = "The name of the app setting that should contain the client secret to use for Azure AD authentication."
   value       = azurerm_windows_web_app.this.auth_settings[0].active_directory[0].client_secret_setting_name
 }
 

--- a/modules/windows-app/variables.tf
+++ b/modules/windows-app/variables.tf
@@ -32,7 +32,7 @@ variable "aad_client_id" {
 }
 
 variable "aad_client_secret_setting_name" {
-  description = "The name of the app setting where the client secret of the App Registration to use for Azure AD authentication must be stored."
+  description = "The name of the app setting that should contain the client secret to use for Azure AD authentication."
   type        = string
   default     = "AAD_CLIENT_SECRET"
   nullable    = false

--- a/modules/windows-app/variables.tf
+++ b/modules/windows-app/variables.tf
@@ -20,7 +20,7 @@ variable "service_plan_id" {
 }
 
 variable "auth_settings_enabled" {
-  description = "Should authentication be enabled for this Windows Web App?"
+  description = "Should the built-in authentication settings be enabled for this Windows Web App?"
   type        = bool
   default     = true
   nullable    = false


### PR DESCRIPTION
Azure AD authentication already optional through use of `auth_settings_enabled` variable.

Simply update variable descriptions to be more clear instead.

Closes #49 