### PR TITLE
feat: use managed identity for keyvault refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apps"></a> [apps](#input\_apps) | A map of identifier => Linux/Windows Web App objects | <pre>map(object({<br>    name                           = string<br>    auth_settings_enabled          = optional(bool)<br>    aad_client_id                  = string<br>    aad_client_secret_setting_name = optional(string)<br>    acr_managed_identity_client_id = optional(string)<br>    managed_identity_ids           = optional(list(string))<br>    custom_hostnames               = optional(list(string))<br>  }))</pre> | `{}` | no |
+| <a name="input_apps"></a> [apps](#input\_apps) | A map of identifier => Linux/Windows Web App objects | <pre>map(object({<br>    name                            = string<br>    auth_settings_enabled           = optional(bool)<br>    aad_client_id                   = string<br>    aad_client_secret_setting_name  = optional(string)<br>    key_vault_reference_identity_id = optional(string)<br>    acr_managed_identity_client_id  = optional(string)<br>    managed_identity_ids            = optional(list(string))<br>    custom_hostnames                = optional(list(string))<br>  }))</pre> | `{}` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
 | <a name="input_os_type"></a> [os\_type](#input\_os\_type) | The OS type for the apps to be hosted on this Web App service plan. | `string` | `"Linux"` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to create the resources in. | `string` | n/a | yes |

--- a/modules/linux-app/README.md
+++ b/modules/linux-app/README.md
@@ -35,6 +35,7 @@ No modules.
 | <a name="input_acr_managed_identity_client_id"></a> [acr\_managed\_identity\_client\_id](#input\_acr\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | `null` | no |
 | <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should the built-in authentication settings be enabled for this Linux Web App? | `bool` | `true` | no |
 | <a name="input_custom_hostnames"></a> [custom\_hostnames](#input\_custom\_hostnames) | A list of custom hostnames to bind to this Linux Web App. | `list(string)` | `[]` | no |
+| <a name="input_key_vault_reference_identity_id"></a> [key\_vault\_reference\_identity\_id](#input\_key\_vault\_reference\_identity\_id) | The ID of the Managed Identity that will be used to fetch app settings sourced from Key Vault. | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
 | <a name="input_managed_identity_ids"></a> [managed\_identity\_ids](#input\_managed\_identity\_ids) | The IDs of the Managed Identities to assign to this Linux Web App. | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of this Linux Web App. | `string` | `null` | no |

--- a/modules/linux-app/main.tf
+++ b/modules/linux-app/main.tf
@@ -1,8 +1,9 @@
 resource "azurerm_linux_web_app" "this" {
-  name                = var.name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  service_plan_id     = var.service_plan_id
+  name                            = var.name
+  location                        = var.location
+  resource_group_name             = var.resource_group_name
+  service_plan_id                 = var.service_plan_id
+  key_vault_reference_identity_id = var.key_vault_reference_identity_id
 
   https_only = true
 

--- a/modules/linux-app/variables.tf
+++ b/modules/linux-app/variables.tf
@@ -38,6 +38,12 @@ variable "aad_client_secret_setting_name" {
   nullable    = false
 }
 
+variable "key_vault_reference_identity_id" {
+  description = "The ID of the Managed Identity that will be used to fetch app settings sourced from Key Vault."
+  type        = string
+  default     = null
+}
+
 variable "acr_managed_identity_client_id" {
   description = "The client ID of the Managed Identity that will be used to pull from the Container Registry."
   type        = string

--- a/modules/windows-app/README.md
+++ b/modules/windows-app/README.md
@@ -35,6 +35,7 @@ No modules.
 | <a name="input_acr_managed_identity_client_id"></a> [acr\_managed\_identity\_client\_id](#input\_acr\_managed\_identity\_client\_id) | The client ID of the Managed Identity that will be used to pull from the Container Registry. | `string` | `null` | no |
 | <a name="input_auth_settings_enabled"></a> [auth\_settings\_enabled](#input\_auth\_settings\_enabled) | Should the built-in authentication settings be enabled for this Windows Web App? | `bool` | `true` | no |
 | <a name="input_custom_hostnames"></a> [custom\_hostnames](#input\_custom\_hostnames) | A list of custom hostnames to bind to this Windows Web App. | `list(string)` | `[]` | no |
+| <a name="input_key_vault_reference_identity_id"></a> [key\_vault\_reference\_identity\_id](#input\_key\_vault\_reference\_identity\_id) | The ID of the Managed Identity that will be used to fetch app settings sourced from Key Vault. | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
 | <a name="input_managed_identity_ids"></a> [managed\_identity\_ids](#input\_managed\_identity\_ids) | The IDs of the Managed Identities to assign to this Windows Web App. | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of this Windows Web App. | `string` | `null` | no |

--- a/modules/windows-app/main.tf
+++ b/modules/windows-app/main.tf
@@ -1,8 +1,9 @@
 resource "azurerm_windows_web_app" "this" {
-  name                = var.name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  service_plan_id     = var.service_plan_id
+  name                            = var.name
+  location                        = var.location
+  resource_group_name             = var.resource_group_name
+  service_plan_id                 = var.service_plan_id
+  key_vault_reference_identity_id = var.key_vault_reference_identity_id
 
   https_only = true
 

--- a/modules/windows-app/variables.tf
+++ b/modules/windows-app/variables.tf
@@ -38,6 +38,12 @@ variable "aad_client_secret_setting_name" {
   nullable    = false
 }
 
+variable "key_vault_reference_identity_id" {
+  description = "The ID of the Managed Identity that will be used to fetch app settings sourced from Key Vault."
+  type        = string
+  default     = null
+}
+
 variable "acr_managed_identity_client_id" {
   description = "The client ID of the Managed Identity that will be used to pull from the Container Registry."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -28,13 +28,14 @@ variable "sku_name" {
 variable "apps" {
   description = "A map of identifier => Linux/Windows Web App objects"
   type = map(object({
-    name                           = string
-    auth_settings_enabled          = optional(bool)
-    aad_client_id                  = string
-    aad_client_secret_setting_name = optional(string)
-    acr_managed_identity_client_id = optional(string)
-    managed_identity_ids           = optional(list(string))
-    custom_hostnames               = optional(list(string))
+    name                            = string
+    auth_settings_enabled           = optional(bool)
+    aad_client_id                   = string
+    aad_client_secret_setting_name  = optional(string)
+    key_vault_reference_identity_id = optional(string)
+    acr_managed_identity_client_id  = optional(string)
+    managed_identity_ids            = optional(list(string))
+    custom_hostnames                = optional(list(string))
   }))
   default = {}
 }


### PR DESCRIPTION
Specify a managed identity that will be used to fetch app settings sourced from Key Vault.