### PR TITLE
fix: output null if identity not configured

### DIFF
--- a/modules/app/outputs.tf
+++ b/modules/app/outputs.tf
@@ -10,10 +10,10 @@ output "name" {
 
 output "identity_principal_id" {
   description = "The principal ID of the system-assigned identity of this Web App."
-  value       = var.identity != null ? local.web_app.identity[0].principal_id : null
+  value       = try(local.web_app.identity[0].principal_id, null)
 }
 
 output "identity_tenant_id" {
   description = "The tenant ID of the system-assigned identity of this Web App."
-  value       = var.identity != null ? local.web_app.identity[0].tenant_id : null
+  value       = try(local.web_app.identity[0].tenant_id, null)
 }


### PR DESCRIPTION
Fix logic that would trow an error if trying to retrieve identity if it is not configured.