### PR TITLE
fix: disable auth settings by default

### DIFF
--- a/examples/active-directory-auth/main.tf
+++ b/examples/active-directory-auth/main.tf
@@ -34,6 +34,7 @@ module "web_app" {
   resource_group_name        = azurerm_resource_group.this.name
   location                   = azurerm_resource_group.this.location
   app_service_plan_name      = "plan-${random_id.this.hex}"
+  auth_settings_enabled      = true
   log_analytics_workspace_id = module.log_analytics.workspace_id
 
   app_settings = {

--- a/modules/app/variables.tf
+++ b/modules/app/variables.tf
@@ -38,7 +38,7 @@ variable "app_settings" {
 variable "auth_settings_enabled" {
   description = "Should the built-in authentication settings be enabled for this Web App?"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "auth_settings_active_directory" {

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "sku_name" {
 variable "auth_settings_enabled" {
   description = "Should the built-in authentication settings be enabled for this Web App?"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "auth_settings_active_directory" {


### PR DESCRIPTION
Enabling auth settings (previously by default) while not configuring any auth settings providers makes the web app inaccessible.