### PR TITLE
refactor: set identity type to system-assigned by default

### DIFF
--- a/modules/app/variables.tf
+++ b/modules/app/variables.tf
@@ -74,7 +74,7 @@ variable "identity" {
   description = "The identity or identities to configure for this Web App."
 
   type = object({
-    type         = string
+    type         = optional(string, "SystemAssigned")
     identity_ids = optional(list(string), [])
   })
 

--- a/variables.tf
+++ b/variables.tf
@@ -80,7 +80,7 @@ variable "identity" {
   description = "The identity or identities to configure for this Web App."
 
   type = object({
-    type         = string
+    type         = optional(string, "SystemAssigned")
     identity_ids = optional(list(string), [])
   })
 


### PR DESCRIPTION
Identity requires the user to specify a type of either `SystemAssigned`, `UserAssigned` or both.

Set type to `SystemAssigned` by default to simplify usage.