### PR TITLE
fix: only configure auth settings when enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,16 +27,20 @@ resource "azurerm_linux_web_app" "this" {
 
   tags = var.tags
 
-  auth_settings {
-    enabled             = var.auth_settings_enabled
-    token_store_enabled = true
+  dynamic "auth_settings" {
+    for_each = length(var.auth_settings_active_directory) > 0 ? [1] : []
 
-    dynamic "active_directory" {
-      for_each = var.auth_settings_active_directory
+    content {
+      enabled             = var.auth_settings_enabled
+      token_store_enabled = true
 
-      content {
-        client_id                  = active_directory.value["client_id"]
-        client_secret_setting_name = active_directory.value["client_secret_setting_name"]
+      dynamic "active_directory" {
+        for_each = var.auth_settings_active_directory
+
+        content {
+          client_id                  = active_directory.value["client_id"]
+          client_secret_setting_name = active_directory.value["client_secret_setting_name"]
+        }
       }
     }
   }
@@ -106,16 +110,20 @@ resource "azurerm_windows_web_app" "this" {
 
   tags = var.tags
 
-  auth_settings {
-    enabled             = var.auth_settings_enabled
-    token_store_enabled = true
+  dynamic "auth_settings" {
+    for_each = length(var.auth_settings_active_directory) > 0 ? [1] : []
 
-    dynamic "active_directory" {
-      for_each = var.auth_settings_active_directory
+    content {
+      enabled             = var.auth_settings_enabled
+      token_store_enabled = true
 
-      content {
-        client_id                  = active_directory.value["client_id"]
-        client_secret_setting_name = active_directory.value["client_secret_setting_name"]
+      dynamic "active_directory" {
+        for_each = var.auth_settings_active_directory
+
+        content {
+          client_id                  = active_directory.value["client_id"]
+          client_secret_setting_name = active_directory.value["client_secret_setting_name"]
+        }
       }
     }
   }


### PR DESCRIPTION
Azure automatically removes the `auth_settings` block when no actual auth settings (e.g. `active_directory`) are configured.

Add a check to only create the block when auth settings are to be configured.