### PR TITLE
refactor!: follow variable best practices

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,6 @@
 locals {
   is_windows = var.kind == "Windows"
   web_app    = local.is_windows ? azurerm_windows_web_app.this[0] : azurerm_linux_web_app.this[0]
-
-  custom_hostnames = {
-    for v in var.custom_hostnames : v["hostname"] => v
-  }
 }
 
 data "azurerm_client_config" "current" {}
@@ -168,7 +164,7 @@ resource "azurerm_windows_web_app" "this" {
 }
 
 resource "azurerm_app_service_custom_hostname_binding" "this" {
-  for_each = local.custom_hostnames
+  for_each = var.custom_hostname_bindings
 
   hostname            = each.value["hostname"]
   app_service_name    = local.web_app.name
@@ -176,13 +172,13 @@ resource "azurerm_app_service_custom_hostname_binding" "this" {
 }
 
 resource "azurerm_app_service_managed_certificate" "this" {
-  for_each = local.custom_hostnames
+  for_each = var.custom_hostname_bindings
 
   custom_hostname_binding_id = azurerm_app_service_custom_hostname_binding.this[each.key].id
 }
 
 resource "azurerm_app_service_certificate_binding" "this" {
-  for_each = local.custom_hostnames
+  for_each = var.custom_hostname_bindings
 
   hostname_binding_id = azurerm_app_service_custom_hostname_binding.this[each.key].id
   certificate_id      = azurerm_app_service_managed_certificate.this[each.key].id

--- a/variables.tf
+++ b/variables.tf
@@ -129,15 +129,15 @@ variable "http_logs_file_system_retention_in_days" {
   default     = 0
 }
 
-variable "custom_hostnames" {
+variable "custom_hostname_bindings" {
   description = "A list of custom hostnames to bind to this Web App."
 
-  type = list(object({
+  type = map(object({
     hostname  = string
     ssl_state = optional(string, "SniEnabled")
   }))
 
-  default = []
+  default = {}
 }
 
 variable "log_analytics_workspace_id" {


### PR DESCRIPTION
Follow variable naming and type conventions.

BREAKING CHANGE: variable `custom_hostnames` renamed to
`custom_hostname_bindings` and type changed from `list` to `map`.