### PR TITLE
feat!: create multiple diagnostic settings

### DIFF
--- a/examples/active-directory-auth/main.tf
+++ b/examples/active-directory-auth/main.tf
@@ -38,12 +38,17 @@ module "app_service" {
 module "web_app" {
   source = "../.."
 
-  app_name                   = "app-${random_id.this.hex}"
-  resource_group_name        = azurerm_resource_group.this.name
-  location                   = azurerm_resource_group.this.location
-  app_service_plan_id        = module.app_service.plan_id
-  log_analytics_workspace_id = module.log_analytics.workspace_id
-  auth_settings_enabled      = true
+  app_name              = "app-${random_id.this.hex}"
+  resource_group_name   = azurerm_resource_group.this.name
+  location              = azurerm_resource_group.this.location
+  app_service_plan_id   = module.app_service.plan_id
+  auth_settings_enabled = true
+
+  diagnostic_settings = {
+    "audit" = {
+      log_analytics_workspace_id = module.log_analytics.workspace_id
+    }
+  }
 
   auth_settings_active_directory = [
     {

--- a/examples/container-app/main.tf
+++ b/examples/container-app/main.tf
@@ -63,9 +63,14 @@ module "web_app" {
   resource_group_name                           = azurerm_resource_group.this.name
   location                                      = azurerm_resource_group.this.location
   app_service_plan_id                           = module.app_service.plan_id
-  log_analytics_workspace_id                    = module.log_analytics.workspace_id
   container_registry_use_managed_identity       = true
   container_registry_managed_identity_client_id = azurerm_user_assigned_identity.this.client_id
+
+  diagnostic_settings = {
+    "audit" = {
+      log_analytics_workspace_id = module.log_analytics.workspace_id
+    }
+  }
 
   identity = {
     type         = "UserAssigned"

--- a/examples/linux-app/main.tf
+++ b/examples/linux-app/main.tf
@@ -38,9 +38,14 @@ module "app_service" {
 module "web_app" {
   source = "../.."
 
-  app_name                   = "app-${random_id.this.hex}"
-  resource_group_name        = azurerm_resource_group.this.name
-  location                   = azurerm_resource_group.this.location
-  app_service_plan_id        = module.app_service.plan_id
-  log_analytics_workspace_id = module.log_analytics.workspace_id
+  app_name            = "app-${random_id.this.hex}"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  app_service_plan_id = module.app_service.plan_id
+
+  diagnostic_settings = {
+    "audit" = {
+      log_analytics_workspace_id = module.log_analytics.workspace_id
+    }
+  }
 }

--- a/examples/vnet-integration/main.tf
+++ b/examples/vnet-integration/main.tf
@@ -57,10 +57,15 @@ module "app_service" {
 module "web_app" {
   source = "../.."
 
-  app_name                   = "app-${random_id.this.hex}"
-  resource_group_name        = azurerm_resource_group.this.name
-  location                   = azurerm_resource_group.this.location
-  app_service_plan_id        = module.app_service.plan_id
-  log_analytics_workspace_id = module.log_analytics.workspace_id
-  virtual_network_subnet_id  = module.network.subnet_ids["app"]
+  app_name                  = "app-${random_id.this.hex}"
+  resource_group_name       = azurerm_resource_group.this.name
+  location                  = azurerm_resource_group.this.location
+  app_service_plan_id       = module.app_service.plan_id
+  virtual_network_subnet_id = module.network.subnet_ids["app"]
+
+  diagnostic_settings = {
+    "audit" = {
+      log_analytics_workspace_id = module.log_analytics.workspace_id
+    }
+  }
 }

--- a/examples/windows-app/main.tf
+++ b/examples/windows-app/main.tf
@@ -38,10 +38,15 @@ module "app_service" {
 module "web_app" {
   source = "../.."
 
-  app_name                   = "app-${random_id.this.hex}"
-  resource_group_name        = azurerm_resource_group.this.name
-  location                   = azurerm_resource_group.this.location
-  app_service_plan_id        = module.app_service.plan_id
-  log_analytics_workspace_id = module.log_analytics.workspace_id
-  kind                       = "Windows"
+  app_name            = "app-${random_id.this.hex}"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  app_service_plan_id = module.app_service.plan_id
+  kind                = "Windows"
+
+  diagnostic_settings = {
+    "audit" = {
+      log_analytics_workspace_id = module.log_analytics.workspace_id
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -186,12 +186,14 @@ resource "azurerm_app_service_certificate_binding" "this" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {
-  name                       = "audit-logs"
+  for_each = var.diagnostic_settings
+
+  name                       = each.value["name"]
   target_resource_id         = local.web_app.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
+  log_analytics_workspace_id = each.value["log_analytics_workspace_id"]
 
   dynamic "enabled_log" {
-    for_each = toset(var.diagnostic_setting_enabled_log_categories)
+    for_each = toset(each.value["enabled_log_categories"])
 
     content {
       category = enabled_log.value

--- a/variables.tf
+++ b/variables.tf
@@ -140,29 +140,25 @@ variable "custom_hostname_bindings" {
   default = {}
 }
 
-variable "log_analytics_workspace_id" {
-  description = "The ID of the Log Analytics workspace to send diagnostics to."
-  type        = string
-}
+variable "diagnostic_settings" {
+  description = "A map of diagnostic settings to create for this Web App."
 
-variable "log_analytics_destination_type" {
-  description = "The type of log analytics destination to use for this Log Analytics Workspace."
-  type        = string
-  default     = null
-}
+  type = map(object({
+    # Required properties
+    log_analytics_workspace_id = string
 
-variable "diagnostic_setting_enabled_log_categories" {
-  description = "A list of log categories to be enabled for this diagnostic setting."
-  type        = list(string)
+    # Optional properties
+    name                   = optional(string, "audit-logs")
+    enabled_log_categories = optional(list(string), ["AppServiceHTTPLogs", "AppServiceConsoleLogs", "AppServiceAppLogs", "AppServiceAuditLogs", "AppServiceIPSecAuditLogs", "AppServicePlatformLogs"])
+  }))
 
-  default = [
-    "AppServiceHTTPLogs",
-    "AppServiceConsoleLogs",
-    "AppServiceAppLogs",
-    "AppServiceAuditLogs",
-    "AppServiceIPSecAuditLogs",
-    "AppServicePlatformLogs"
-  ]
+  nullable = false
+
+  # Ensure at least one diagnostic setting is created
+  validation {
+    condition     = length(var.diagnostic_settings) > 0
+    error_message = "At least one diagnostic setting must be created!"
+  }
 }
 
 variable "tags" {


### PR DESCRIPTION
Allow creation of multiple diagnostic settings if needed.

Enforce creation of at least one diagnostic setting to keep same default behaviour as before.