### PR TITLE
fix: set app settings to empty map

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "azurerm_linux_web_app" "this" {
   virtual_network_subnet_id       = var.virtual_network_subnet_id
 
   # App settings should be configured during deployment.
-  app_settings = null
+  app_settings = {}
 
   # HTTPS enforced by Equinor policy
   https_only = true
@@ -95,7 +95,7 @@ resource "azurerm_windows_web_app" "this" {
   virtual_network_subnet_id       = var.virtual_network_subnet_id
 
   # App settings should be configured during deployment.
-  app_settings = null
+  app_settings = {}
 
   # HTTPS enforced by Equinor policy
   https_only = true


### PR DESCRIPTION
Set app settings to empty map when creating the web app.

Previously when setting to null, Azure would automatically set it to a second map, causing `terraform plan` to note it as a change outside of Terraform.

Changes to app settings will still be ignored.