### PR TITLE
feat: auto assign Key Vault reference identity ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ locals {
   # If identity_ids is non-empty, value is "UserAssigned".
   # If system_assigned_identity_enabled is true and identity_ids is non-empty, value is "SystemAssigned, UserAssigned".
   identity_type = join(", ", compact([var.system_assigned_identity_enabled ? "SystemAssigned" : "", length(var.identity_ids) > 0 ? "UserAssigned" : ""]))
+  identity_ids  = compact([var.key_vault_reference_identity_id])
 }
 
 data "azurerm_client_config" "current" {}
@@ -58,7 +59,7 @@ resource "azurerm_linux_web_app" "this" {
 
     content {
       type         = local.identity_type
-      identity_ids = var.identity_ids
+      identity_ids = concat(local.identity_ids, var.identity_ids)
     }
   }
 
@@ -141,7 +142,7 @@ resource "azurerm_windows_web_app" "this" {
 
     content {
       type         = local.identity_type
-      identity_ids = var.identity_ids
+      identity_ids = concat(local.identity_ids, var.identity_ids)
     }
   }
 


### PR DESCRIPTION
If a Key Vault reference identity ID is specified, automatically assign it to the Web App.

This simplifies the configuration of the Key Vault reference identity, as its ID only has to be specified once.