### PR TITLE
feat!: migrate to auth settings V2

### DIFF
--- a/examples/active-directory-auth/main.tf
+++ b/examples/active-directory-auth/main.tf
@@ -43,14 +43,8 @@ module "web_app" {
   location                   = azurerm_resource_group.this.location
   app_service_plan_id        = module.app_service.plan_id
   log_analytics_workspace_id = module.log_analytics.workspace_id
-  auth_settings_enabled      = true
 
-  auth_settings_active_directory = [
-    {
-      client_id = "00000000-0000-0000-0000-000000000000"
-    }
-  ]
-
+  active_directory_client_id = "00000000-0000-0000-0000-000000000000"
   # Store client secret as a slot-sticky app setting named "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET".
   # Use Key Vault references to managed the secret in Azure Key Vault.
 }

--- a/main.tf
+++ b/main.tf
@@ -32,20 +32,21 @@ resource "azurerm_linux_web_app" "this" {
 
   tags = var.tags
 
-  dynamic "auth_settings" {
-    for_each = length(var.auth_settings_active_directory) > 0 ? [1] : []
+  dynamic "auth_settings_v2" {
+    for_each = var.active_directory_client_id == null ? [] : [1]
 
     content {
-      enabled             = var.auth_settings_enabled
-      token_store_enabled = true
+      auth_enabled = true
 
-      dynamic "active_directory" {
-        for_each = var.auth_settings_active_directory
+      login {
+        token_store_enabled = true
+      }
 
-        content {
-          client_id                  = active_directory.value["client_id"]
-          client_secret_setting_name = active_directory.value["client_secret_setting_name"]
-        }
+      # TODO: use "microsoft_v2" instead? What's the difference?
+      active_directory_v2 {
+        tenant_auth_endpoint       = "https://login.microsoftonline.com/v2.0/${data.azurerm_client_config.current.tenant_id}/"
+        client_id                  = var.active_directory_client_id
+        client_secret_setting_name = var.active_directory_client_secret_setting_name
       }
     }
   }
@@ -117,20 +118,21 @@ resource "azurerm_windows_web_app" "this" {
 
   tags = var.tags
 
-  dynamic "auth_settings" {
-    for_each = length(var.auth_settings_active_directory) > 0 ? [1] : []
+  dynamic "auth_settings_v2" {
+    for_each = var.active_directory_client_id == null ? [] : [1]
 
     content {
-      enabled             = var.auth_settings_enabled
-      token_store_enabled = true
+      auth_enabled = true
 
-      dynamic "active_directory" {
-        for_each = var.auth_settings_active_directory
+      login {
+        token_store_enabled = true
+      }
 
-        content {
-          client_id                  = active_directory.value["client_id"]
-          client_secret_setting_name = active_directory.value["client_secret_setting_name"]
-        }
+      # TODO: use "microsoft_v2" instead? What's the difference?
+      active_directory_v2 {
+        tenant_auth_endpoint       = "https://login.microsoftonline.com/v2.0/${data.azurerm_client_config.current.tenant_id}/"
+        client_id                  = var.active_directory_client_id
+        client_secret_setting_name = var.active_directory_client_secret_setting_name
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -36,15 +36,16 @@ resource "azurerm_linux_web_app" "this" {
     for_each = var.active_directory_client_id == null ? [] : [1]
 
     content {
-      auth_enabled = true
+      auth_enabled           = true
+      require_authentication = true
+      default_provider       = "azureactivedirectory"
 
       login {
         token_store_enabled = true
       }
 
-      # TODO: use "microsoft_v2" instead? What's the difference?
       active_directory_v2 {
-        tenant_auth_endpoint       = "https://login.microsoftonline.com/v2.0/${data.azurerm_client_config.current.tenant_id}/"
+        tenant_auth_endpoint       = "https://sts.windows.net/${data.azurerm_client_config.current.tenant_id}/v2.0"
         client_id                  = var.active_directory_client_id
         client_secret_setting_name = var.active_directory_client_secret_setting_name
       }

--- a/main.tf
+++ b/main.tf
@@ -123,15 +123,16 @@ resource "azurerm_windows_web_app" "this" {
     for_each = var.active_directory_client_id == null ? [] : [1]
 
     content {
-      auth_enabled = true
+      auth_enabled           = true
+      require_authentication = true
+      default_provider       = "azureactivedirectory"
 
       login {
         token_store_enabled = true
       }
 
-      # TODO: use "microsoft_v2" instead? What's the difference?
       active_directory_v2 {
-        tenant_auth_endpoint       = "https://login.microsoftonline.com/v2.0/${data.azurerm_client_config.current.tenant_id}/"
+        tenant_auth_endpoint       = "https://sts.windows.net/${data.azurerm_client_config.current.tenant_id}/v2.0"
         client_id                  = var.active_directory_client_id
         client_secret_setting_name = var.active_directory_client_secret_setting_name
       }

--- a/variables.tf
+++ b/variables.tf
@@ -29,22 +29,28 @@ variable "kind" {
   }
 }
 
-variable "auth_settings_enabled" {
-  description = "Should the built-in authentication settings be enabled for this Web App?"
-  type        = bool
-  default     = false
+variable "active_directory_client_id" {
+  description = "The client ID of the Azure AD app registration to use for authentication."
+  type        = string
+  default     = null
 }
 
-variable "auth_settings_active_directory" {
-  description = "A list of authentication settings using the Active Directory provider to configure for this web app."
-
-  type = list(object({
-    client_id                  = string
-    client_secret_setting_name = optional(string, "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET")
-  }))
-
-  default = []
+variable "active_directory_client_secret_setting_name" {
+  description = "The name of the app setting to get the Azure AD app registration client secret from."
+  type        = string
+  default     = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
 }
+
+# variable "auth_settings_active_directory" {
+#   description = "The authentication settings using the Active Directory provider to configure for this web app."
+
+#   type = object({
+#     client_id                  = string
+#     client_secret_setting_name = optional(string, "")
+#   })
+
+#   default = null
+# }
 
 variable "client_affinity_enabled" {
   description = "Should Client Affinity be enabled?"

--- a/variables.tf
+++ b/variables.tf
@@ -41,17 +41,6 @@ variable "active_directory_client_secret_setting_name" {
   default     = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
 }
 
-# variable "auth_settings_active_directory" {
-#   description = "The authentication settings using the Active Directory provider to configure for this web app."
-
-#   type = object({
-#     client_id                  = string
-#     client_secret_setting_name = optional(string, "")
-#   })
-
-#   default = null
-# }
-
 variable "client_affinity_enabled" {
   description = "Should Client Affinity be enabled?"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.39.0"
+      version = ">= 3.45.0"
     }
   }
 }


### PR DESCRIPTION
Also simplify configuration of auth settings (see `active-directory-auth` example).

BREAKING CHANGE: remove variables `auth_settings_enabled` and `auth_settings_active_directory`, add variables `active_directory_client_id` and `active_directory_client_secret_setting_name`.

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
