### PR TITLE
fix: enabling auth settings breaks website

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,8 +40,16 @@ resource "azurerm_linux_web_app" "this" {
       require_authentication = true
       default_provider       = "azureactivedirectory"
 
+      # The following values are set automatically by Azure.
+      # Set explicitly to prevent Terraform from detecting them as "changes made outside of Terraform".
+      excluded_paths = []
+
       login {
         token_store_enabled = true
+
+        # The following values are set automatically by Azure.
+        # Set explicitly to prevent Terraform from detecting them as "changes made outside of Terraform".
+        allowed_external_redirect_urls = []
       }
 
       active_directory_v2 {
@@ -50,6 +58,15 @@ resource "azurerm_linux_web_app" "this" {
 
         tenant_auth_endpoint = "https://sts.windows.net/${data.azurerm_client_config.current.tenant_id}/v2.0"
         allowed_audiences    = ["api://${var.active_directory_client_id}"]
+
+        # The following values are set automatically by Azure.
+        # Set explicitly to prevent Terraform from detecting them as "changes made outside of Terraform".
+        allowed_groups                  = []
+        allowed_applications            = []
+        allowed_identities              = []
+        jwt_allowed_client_applications = []
+        jwt_allowed_groups              = []
+        login_parameters                = {}
       }
     }
   }
@@ -129,8 +146,16 @@ resource "azurerm_windows_web_app" "this" {
       require_authentication = true
       default_provider       = "azureactivedirectory"
 
+      # The following values are set automatically by Azure.
+      # Set explicitly to prevent Terraform from detecting them as "changes made outside of Terraform".
+      excluded_paths = []
+
       login {
         token_store_enabled = true
+
+        # The following values are set automatically by Azure.
+        # Set explicitly to prevent Terraform from detecting them as "changes made outside of Terraform".
+        allowed_external_redirect_urls = []
       }
 
       active_directory_v2 {
@@ -139,6 +164,15 @@ resource "azurerm_windows_web_app" "this" {
 
         tenant_auth_endpoint = "https://sts.windows.net/${data.azurerm_client_config.current.tenant_id}/v2.0"
         allowed_audiences    = ["api://${var.active_directory_client_id}"]
+
+        # The following values are set automatically by Azure.
+        # Set explicitly to prevent Terraform from detecting them as "changes made outside of Terraform".
+        allowed_groups                  = []
+        allowed_applications            = []
+        allowed_identities              = []
+        jwt_allowed_client_applications = []
+        jwt_allowed_groups              = []
+        login_parameters                = {}
       }
     }
   }


### PR DESCRIPTION
Set required value for `allowed_audiences`.

Also set explicit values for several arguments to prevent Terraform from detecting them as "changed outside of Terraform".

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
