### PR TITLE
feat: auto use managed identity for container registry

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,8 @@ locals {
   is_windows = var.kind == "Windows"
   web_app    = local.is_windows ? azurerm_windows_web_app.this[0] : azurerm_linux_web_app.this[0]
 
+  container_registry_use_managed_identity = coalesce(var.container_registry_use_managed_identity, var.container_registry_managed_identity_client_id != null)
+
   # Auto assign Key Vault reference identity
   identity_ids = concat(compact([var.key_vault_reference_identity_id]), var.identity_ids)
 
@@ -74,7 +76,7 @@ resource "azurerm_linux_web_app" "this" {
   site_config {
     vnet_route_all_enabled                        = var.vnet_route_all_enabled
     websockets_enabled                            = var.websockets_enabled
-    container_registry_use_managed_identity       = var.container_registry_use_managed_identity
+    container_registry_use_managed_identity       = local.container_registry_use_managed_identity
     container_registry_managed_identity_client_id = var.container_registry_managed_identity_client_id
     ftps_state                                    = var.ftps_state
   }
@@ -180,7 +182,7 @@ resource "azurerm_windows_web_app" "this" {
   site_config {
     vnet_route_all_enabled                        = var.vnet_route_all_enabled
     websockets_enabled                            = var.websockets_enabled
-    container_registry_use_managed_identity       = var.container_registry_use_managed_identity
+    container_registry_use_managed_identity       = local.container_registry_use_managed_identity
     container_registry_managed_identity_client_id = var.container_registry_managed_identity_client_id
     ftps_state                                    = var.ftps_state
   }

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "websockets_enabled" {
 variable "container_registry_use_managed_identity" {
   description = "Should connections to Container Registry use Managed Identity?"
   type        = bool
-  default     = false
+  default     = null
 }
 
 variable "container_registry_managed_identity_client_id" {


### PR DESCRIPTION
Automatically enable Managed Identity authentication to Container Registry if a value is provided for the `container_registry_managed_identity_client_id` variable.

Managed Identity authentication can still be manually enabled/disabled using the `container_registry_use_managed_identity` variable.

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
