### PR TITLE
feat: manage app settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_linux_web_app" "this" {
   location                        = var.location
   resource_group_name             = var.resource_group_name
   service_plan_id                 = var.app_service_plan_id
-  app_settings                    = var.app_settings
+  app_settings                    = null # Configure using "azapi_update_resource.app_settings" instead
   https_only                      = local.https_only
   client_affinity_enabled         = var.client_affinity_enabled
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
@@ -152,7 +152,7 @@ resource "azurerm_windows_web_app" "this" {
   location                        = var.location
   resource_group_name             = var.resource_group_name
   service_plan_id                 = var.app_service_plan_id
-  app_settings                    = var.app_settings
+  app_settings                    = null # Configure using "azapi_update_resource.app_settings" instead
   https_only                      = local.https_only
   client_affinity_enabled         = var.client_affinity_enabled
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
@@ -251,6 +251,24 @@ resource "azurerm_windows_web_app" "this" {
       logs[0].application_logs
     ]
   }
+}
+
+resource "azapi_update_resource" "app_settings" {
+  count = var.app_settings != null ? 1 : 0
+
+  type        = "Microsoft.Web/sites@2022-09-01"
+  resource_id = local.web_app.id
+
+  body = jsonencode({
+    properties = {
+      siteConfig = {
+        appSettings = [for name, value in var.app_settings : {
+          name  = name
+          value = value
+        }]
+      }
+    }
+  })
 }
 
 resource "azurerm_app_service_custom_hostname_binding" "this" {

--- a/main.tf
+++ b/main.tf
@@ -253,6 +253,10 @@ resource "azurerm_windows_web_app" "this" {
   }
 }
 
+# Manage app settings using AzAPI provider instead of AzureRM.
+# This enables the possibility of manages app settings either in Terraform or outside Terraform.
+# - If you want to manage app settings in Terraform, this resource will be created.
+# - If you want to manage app settings outside of Terraform, this resource won't be created.
 resource "azapi_update_resource" "app_settings" {
   count = var.app_settings != null ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -254,7 +254,7 @@ resource "azurerm_windows_web_app" "this" {
 }
 
 # Manage app settings using AzAPI provider instead of AzureRM.
-# This enables the possibility of manages app settings either in Terraform or outside Terraform.
+# This enables the possibility of managing app settings either in Terraform or outside Terraform.
 # - If you want to manage app settings in Terraform, this resource will be created.
 # - If you want to manage app settings outside of Terraform, this resource won't be created.
 resource "azapi_update_resource" "app_settings" {

--- a/main.tf
+++ b/main.tf
@@ -273,6 +273,11 @@ resource "azapi_update_resource" "app_settings" {
       }
     }
   })
+
+  depends_on = [
+    # Ensure existing Web App operations are complete before trying to update it.
+    local.web_app
+  ]
 }
 
 resource "azurerm_app_service_custom_hostname_binding" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "kind" {
 }
 
 variable "app_settings" {
-  description = "A map of app settings to be configured for this Web App. Note that app settings should be configured outside of Terraform, thus any changes will be ignored."
+  description = "A map of app settings to be configured for this Web App. Note that app settings are often configured outside of Terraform, so configuring app settings in Terraform may cause conflicts."
   type        = map(string)
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "kind" {
 }
 
 variable "app_settings" {
-  description = "A map of app settings to be configured for this Web App. Note that app settings are often configured outside of Terraform, so configuring app settings in Terraform may cause conflicts."
+  description = "A map of app settings to be configured for this Web App. Set to `null` to manage app settings outside of Terraform."
   type        = map(string)
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.45.0"
     }
+
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 1.0.0"
+    }
   }
 }


### PR DESCRIPTION
Allow managing app settings either in or outside of Terraform. Previously, we were only able to manage app settings outside of Terraform.

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
