### PR TITLE
feat: configure Docker registry settings

### DIFF
--- a/examples/container-app/main.tf
+++ b/examples/container-app/main.tf
@@ -14,27 +14,6 @@ module "log_analytics" {
   location            = var.location
 }
 
-module "acr" {
-  source = "github.com/equinor/terraform-azurerm-acr?ref=v5.0.0"
-
-  registry_name              = "cr${random_id.this.hex}"
-  location                   = var.location
-  resource_group_name        = var.resource_group_name
-  log_analytics_workspace_id = module.log_analytics.workspace_id
-}
-
-resource "azurerm_user_assigned_identity" "this" {
-  name                = "id-${random_id.this.hex}"
-  resource_group_name = var.resource_group_name
-  location            = var.location
-}
-
-resource "azurerm_role_assignment" "acr_pull" {
-  scope                = module.acr.registry_id
-  role_definition_name = "AcrPull"
-  principal_id         = azurerm_user_assigned_identity.this.principal_id
-}
-
 module "app_service" {
   source = "github.com/equinor/terraform-azurerm-app-service?ref=v1.0.0"
 
@@ -46,12 +25,14 @@ module "app_service" {
 module "web_app" {
   source = "../.."
 
-  app_name                                      = "app-${random_id.this.hex}"
-  resource_group_name                           = var.resource_group_name
-  location                                      = var.location
-  app_service_plan_id                           = module.app_service.plan_id
-  log_analytics_workspace_id                    = module.log_analytics.workspace_id
-  container_registry_use_managed_identity       = true
-  container_registry_managed_identity_client_id = azurerm_user_assigned_identity.this.client_id
-  identity_ids                                  = [azurerm_user_assigned_identity.this.id]
+  app_name                   = "app-${random_id.this.hex}"
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  app_service_plan_id        = module.app_service.plan_id
+  log_analytics_workspace_id = module.log_analytics.workspace_id
+
+  application_stack = {
+    docker_image_name   = "appsvc/staticsite:latest"
+    docker_registry_url = "https://mcr.microsoft.com"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -105,12 +105,8 @@ resource "azurerm_linux_web_app" "this" {
       for_each = var.application_stack == null ? toset([]) : toset([var.application_stack])
 
       content {
-        docker_image_name = application_stack.value.docker_image_name
-
-        # The following arguments should be configured as app settings instead:
-        # - docker_registry_url
-        # - docker_registry_username
-        # - docker_registry_password
+        docker_image_name   = application_stack.value.docker_image_name
+        docker_registry_url = application_stack.value.docker_registry_url
       }
     }
   }
@@ -223,13 +219,9 @@ resource "azurerm_windows_web_app" "this" {
       for_each = var.application_stack == null ? toset([]) : toset([var.application_stack])
 
       content {
-        docker_image_name = application_stack.value.docker_image_name
-        current_stack     = application_stack.value.current_stack
-
-        # The following arguments should be configured as app settings instead:
-        # - docker_registry_url
-        # - docker_registry_username
-        # - docker_registry_password
+        docker_image_name   = application_stack.value.docker_image_name
+        docker_registry_url = application_stack.value.docker_registry_url
+        current_stack       = application_stack.value.current_stack
       }
     }
   }
@@ -294,6 +286,8 @@ resource "azapi_update_resource" "app_settings" {
       }
     }
   })
+
+  # TODO: ignore changes to DOCKER_* settings
 
   depends_on = [
     # Ensure existing Web App operations are complete before trying to update it.

--- a/main.tf
+++ b/main.tf
@@ -105,8 +105,10 @@ resource "azurerm_linux_web_app" "this" {
       for_each = var.application_stack == null ? toset([]) : toset([var.application_stack])
 
       content {
-        docker_image_name   = application_stack.value.docker_image_name
-        docker_registry_url = application_stack.value.docker_registry_url
+        docker_image_name        = application_stack.value.docker_image_name
+        docker_registry_url      = application_stack.value.docker_registry_url
+        docker_registry_username = application_stack.value.docker_registry_username
+        docker_registry_password = application_stack.value.docker_registry_password
       }
     }
   }
@@ -219,9 +221,11 @@ resource "azurerm_windows_web_app" "this" {
       for_each = var.application_stack == null ? toset([]) : toset([var.application_stack])
 
       content {
-        docker_image_name   = application_stack.value.docker_image_name
-        docker_registry_url = application_stack.value.docker_registry_url
-        current_stack       = application_stack.value.current_stack
+        docker_image_name        = application_stack.value.docker_image_name
+        docker_registry_url      = application_stack.value.docker_registry_url
+        docker_registry_username = application_stack.value.docker_registry_username
+        docker_registry_password = application_stack.value.docker_registry_password
+        current_stack            = application_stack.value.current_stack
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "kind" {
 variable "app_settings" {
   description = "A map of app settings to be configured for this Web App. Set to `null` to manage app settings outside of Terraform."
   type        = map(string)
-  default     = null
+  default     = {}
 
   validation {
     condition     = !contains(keys(coalesce(var.app_settings, {})), "DOCKER_REGISTRY_SERVER_URL")

--- a/variables.tf
+++ b/variables.tf
@@ -33,15 +33,22 @@ variable "app_settings" {
   description = "A map of app settings to be configured for this Web App. Set to `null` to manage app settings outside of Terraform."
   type        = map(string)
   default     = null
+
+  # validation {
+  #   condition     = anytrue([for setting in var.app_settings : contains(["DOCKER_REGISTRY_SERVER_URL", setting])])
+  #   error_message = "App setting \"DOCKER_REGISTRY_SERVER_URL\" must be configured using 'application_stack' instead."
+  # }
 }
 
 variable "application_stack" {
   description = "An object of application stack settings for this Web App. Note that application stack settings are often configured outside of Terraform (for example when deploying code), so configuring application stack settings in Terraform may cause conflicts."
 
   type = object({
-    docker_image_name = string
-    current_stack     = optional(string, null)
+    docker_image_name   = string
+    docker_registry_url = string
+    current_stack       = optional(string, null)
   })
+
   default = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,19 +34,31 @@ variable "app_settings" {
   type        = map(string)
   default     = null
 
-  # validation {
-  #   condition     = anytrue([for setting in var.app_settings : contains(["DOCKER_REGISTRY_SERVER_URL", setting])])
-  #   error_message = "App setting \"DOCKER_REGISTRY_SERVER_URL\" must be configured using 'application_stack' instead."
-  # }
+  validation {
+    condition     = !contains(keys(coalesce(var.app_settings, {})), "DOCKER_REGISTRY_SERVER_URL")
+    error_message = "App setting \"DOCKER_REGISTRY_SERVER_URL\" should not be specified. Configure Docker registry server URL using \"application_stack\" instead."
+  }
+
+  validation {
+    condition     = !contains(keys(coalesce(var.app_settings, {})), "DOCKER_REGISTRY_SERVER_USERNAME")
+    error_message = "App setting \"DOCKER_REGISTRY_SERVER_USERNAME\" should not be specified. Configure Docker registry server username using \"application_stack\" instead."
+  }
+
+  validation {
+    condition     = !contains(keys(coalesce(var.app_settings, {})), "DOCKER_REGISTRY_SERVER_PASSWORD")
+    error_message = "App setting \"DOCKER_REGISTRY_SERVER_PASSWORD\" should not be specified. Configure Docker registry server password using \"application_stack\" instead."
+  }
 }
 
 variable "application_stack" {
   description = "An object of application stack settings for this Web App. Note that application stack settings are often configured outside of Terraform (for example when deploying code), so configuring application stack settings in Terraform may cause conflicts."
 
   type = object({
-    docker_image_name   = string
-    docker_registry_url = string
-    current_stack       = optional(string, null)
+    docker_image_name        = string
+    docker_registry_url      = string
+    docker_registry_username = optional(string)
+    docker_registry_password = optional(string)
+    current_stack            = optional(string)
   })
 
   default = null

--- a/variables.tf
+++ b/variables.tf
@@ -36,13 +36,7 @@ variable "app_settings" {
   nullable    = false
 
   validation {
-    condition = !anytrue([
-      for key in keys(var.app_settings) : contains([
-        "DOCKER_REGISTRY_SERVER_URL",
-        "DOCKER_REGISTRY_SERVER_USERNAME",
-        "DOCKER_REGISTRY_SERVER_PASSWORD"
-    ], key)])
-
+    condition     = length(setintersection(["DOCKER_REGISTRY_SERVER_URL", "DOCKER_REGISTRY_SERVER_USERNAME", "DOCKER_REGISTRY_SERVER_PASSWORD"], keys(var.app_settings))) == 0
     error_message = "Docker settings must be configured using \"application_stack\"."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,23 +30,20 @@ variable "kind" {
 }
 
 variable "app_settings" {
-  description = "A map of app settings to be configured for this Web App. Set to `null` to manage app settings outside of Terraform."
+  description = "A map of app settings to be configured for this Web App."
   type        = map(string)
   default     = {}
+  nullable    = false
 
   validation {
-    condition     = !contains(keys(coalesce(var.app_settings, {})), "DOCKER_REGISTRY_SERVER_URL")
-    error_message = "App setting \"DOCKER_REGISTRY_SERVER_URL\" should not be specified. Configure Docker registry server URL using \"application_stack\" instead."
-  }
+    condition = !anytrue([
+      for key in keys(var.app_settings) : contains([
+        "DOCKER_REGISTRY_SERVER_URL",
+        "DOCKER_REGISTRY_SERVER_USERNAME",
+        "DOCKER_REGISTRY_SERVER_PASSWORD"
+    ], key)])
 
-  validation {
-    condition     = !contains(keys(coalesce(var.app_settings, {})), "DOCKER_REGISTRY_SERVER_USERNAME")
-    error_message = "App setting \"DOCKER_REGISTRY_SERVER_USERNAME\" should not be specified. Configure Docker registry server username using \"application_stack\" instead."
-  }
-
-  validation {
-    condition     = !contains(keys(coalesce(var.app_settings, {})), "DOCKER_REGISTRY_SERVER_PASSWORD")
-    error_message = "App setting \"DOCKER_REGISTRY_SERVER_PASSWORD\" should not be specified. Configure Docker registry server password using \"application_stack\" instead."
+    error_message = "Docker settings must be configured using \"application_stack\"."
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,5 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.45.0"
     }
-
-    azapi = {
-      source  = "Azure/azapi"
-      version = ">= 1.0.0"
-    }
   }
 }


### PR DESCRIPTION
## Changes

- Add properties `docker_registry_url`, `docker_registry_username` and `docker_registry_password` to variable `application_stack`.
- Add validation rule to variable `app_settings` to ensure Docker settings are configured using variable `application_stack` instead.
- Update `container-app` example to demonstrate configuration of Docker settings.

## Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.