### PR TITLE
fix: prevent configuration of HTTP logging using app settings

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,11 @@ variable "app_settings" {
     condition     = length(setintersection(["DOCKER_REGISTRY_SERVER_URL", "DOCKER_REGISTRY_SERVER_USERNAME", "DOCKER_REGISTRY_SERVER_PASSWORD"], keys(var.app_settings))) == 0
     error_message = "Docker settings must be configured using \"application_stack\"."
   }
+
+  validation {
+    condition     = length(setintersection(["WEBSITE_HTTPLOGGING_ENABLED", "WEBSITE_HTTPLOGGING_RETENTION_DAYS", "WEBSITE_HTTPLOGGING_CONTAINER_URL"], keys(var.app_settings))) == 0
+    error_message = "HTTP logging settings must be configured using \"http_logs_file_system_retention_in_mb\" and \"http_logs_file_system_retention_in_days\"."
+  }
 }
 
 variable "application_stack" {


### PR DESCRIPTION
Add validation rule to variable `app_settings` to prevent configuration of the following app settings:
- `WEBSITE_HTTPLOGGING_ENABLED`
- `WEBSITE_HTTPLOGGING_RETENTION_DAYS`
- `WEBSITE_HTTPLOGGING_CONTAINER_URL`

These app settings are set automatically by Terraform based on the values of 
the `azurerm_linux_web_app.this[0].logs[0].http_logs` and `azurerm_windows_web_app.this[0].logs[0].http_logs` block.

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
