### PR TITLE
feat: allowing manual integration toggle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ resource "azurerm_linux_web_app" "this" {
   client_affinity_enabled         = var.client_affinity_enabled
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
   virtual_network_subnet_id       = var.virtual_network_subnet_id
+  use_manual_integration          = var.use_manual_integration
 
   tags = var.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "app_service_plan_id" {
   type        = string
 }
 
+variable "use_manual_integration" {
+  description = "(Optional) Set to false to enable continuous integration, such as webhooks into online repos such as GitHub."
+  type        = string
+  default     = true
+}
+
 variable "kind" {
   description = "The kind of Web App to create."
   type        = string


### PR DESCRIPTION
I need to deploy apps with this feature activated:
![image](https://github.com/equinor/terraform-azurerm-web-app/assets/27433531/172c6626-ccb2-4eff-b557-9d0ca7b6d238)

The [this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_source_control#use_manual_integration) parameter is currently missing.