### PR TITLE
feat: add ip restriction default value variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -201,6 +201,8 @@ resource "azurerm_windows_web_app" "this" {
     container_registry_managed_identity_client_id = var.container_registry_managed_identity_client_id
     always_on                                     = var.always_on
     ftps_state                                    = var.ftps_state
+    ip_restriction_default_action                 = var.ip_restriction_default_action
+    scm_ip_restriction_default_action             = var.scm_ip_restriction_default_action
 
     dynamic "ip_restriction" {
       for_each = var.ip_restrictions

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,8 @@ resource "azurerm_linux_web_app" "this" {
     container_registry_managed_identity_client_id = var.container_registry_managed_identity_client_id
     always_on                                     = var.always_on
     ftps_state                                    = var.ftps_state
+    ip_restriction_default_action                 = var.ip_restriction_default_action
+    scm_ip_restriction_default_action             = var.scm_ip_restriction_default_action
 
     dynamic "ip_restriction" {
       for_each = var.ip_restrictions

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,18 @@ variable "ip_restrictions" {
   default = []
 }
 
+variable "ip_restriction_default_action" {
+  description = "The Default action for traffic that does not match any ip_restriction rule"
+  type        = string
+  default     = "Allow"
+}
+
+variable "scm_ip_restriction_default_action" {
+  description = "The Default action for traffic to the Source Control Manager that does not match any ip_restriction rule"
+  type        = string
+  default     = "Allow"
+}
+
 variable "application_logs_file_system_level" {
   description = "The level of application logs to be enabled. Possible values include \"Verbose\", \"Information\", \"Warning\" and \"Error\"."
   type        = string


### PR DESCRIPTION
### Checklist

I added the `ip_restriction_default_action` and `scm_ip_restriction_default_action` variables to be able to block access to IP addresses that do not match any ip_restriction rule. In the current version, the value is set to its default value `allow` which makes ip_restrictions rules only able to block traffic, not restrict it.

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
