### PR TITLE
fix: correct required provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.45.0"
+      version = ">= 3.95.0"
     }
   }
 }


### PR DESCRIPTION
v3.95 required to set `ip_restriction_default_action` and `scm_ip_restriction_default_action`: https://github.com/hashicorp/terraform-provider-azurerm/blob/main/CHANGELOG.md#3950-march-08-2024

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
