### PR TITLE
fix: ignore changes to common build settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,13 @@ resource "azurerm_linux_web_app" "this" {
     ignore_changes = [
       # This setting turns itself off after 12 hours.
       # Ignore changes to prevent cycle of turning on/off...
-      logs[0].application_logs
+      logs[0].application_logs,
+
+      # Ignore changes to common build settings.
+      # These are usually configured in CI/CD pipelines.
+      app_settings["BUILD"],
+      app_settings["BUILD_NUMBER"],
+      app_settings["BUILD_ID"]
     ]
   }
 }
@@ -258,7 +264,13 @@ resource "azurerm_windows_web_app" "this" {
     ignore_changes = [
       # This setting turns itself off after 12 hours.
       # Ignore changes to prevent cycle of turning on/off...
-      logs[0].application_logs
+      logs[0].application_logs,
+
+      # Ignore changes to common build settings.
+      # These are usually configured in CI/CD pipelines.
+      app_settings["BUILD"],
+      app_settings["BUILD_NUMBER"],
+      app_settings["BUILD_ID"]
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "app_settings" {
   }
 
   validation {
-    condition     = length(setintersection(formatlist(lower("%s"), ["BUILD", "BUILD_NUMBER", "BUILD_ID"]), formatlist(lower("%s"), keys(var.app_settings)))) == 0
+    condition     = length(setintersection([for setting in ["BUILD", "BUILD_NUMBER", "BUILD_ID"] : lower(setting)], [for setting in keys(var.app_settings) : lower(setting)])) == 0
     error_message = "Build settings must be configured outside of Terraform, commonly in a CI/CD pipeline."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,11 @@ variable "app_settings" {
     condition     = length(setintersection(["WEBSITE_HTTPLOGGING_ENABLED", "WEBSITE_HTTPLOGGING_RETENTION_DAYS", "WEBSITE_HTTPLOGGING_CONTAINER_URL"], keys(var.app_settings))) == 0
     error_message = "HTTP logging settings must be configured using \"http_logs_file_system_retention_in_mb\" and \"http_logs_file_system_retention_in_days\"."
   }
+
+  validation {
+    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], keys(var.app_settings))) == 0
+    error_message = "Build settings must be configured outside of Terraform, commonly in a CI/CD pipeline."
+  }
 }
 
 variable "application_stack" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "app_settings" {
   }
 
   validation {
-    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], keys(var.app_settings))) == 0
+    condition     = length(setintersection(formatlist(lower("%s"), ["BUILD", "BUILD_NUMBER", "BUILD_ID"]), formatlist(lower("%s"), keys(var.app_settings)))) == 0
     error_message = "Build settings must be configured outside of Terraform, commonly in a CI/CD pipeline."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "app_settings" {
   }
 
   validation {
-    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], [for key in keys(var.app_settings) : upper(key)])) == 0
+    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], keys(var.app_settings))) == 0
     error_message = "Build settings must be configured outside of Terraform, commonly in a CI/CD pipeline."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "app_settings" {
   }
 
   validation {
-    condition     = length(setintersection([for setting in ["BUILD", "BUILD_NUMBER", "BUILD_ID"] : lower(setting)], [for setting in keys(var.app_settings) : lower(setting)])) == 0
+    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], [for key in keys(var.app_settings) : upper(key)])) == 0
     error_message = "Build settings must be configured outside of Terraform, commonly in a CI/CD pipeline."
   }
 }


### PR DESCRIPTION
App settings `BUILD`, `BUILD_NUMBER` and `BUILD_ID` are commonly used for keeping track of which build is deployed to the Web App. Ignore changes to these settings to allow them to be configured from CI/CD pipelines.

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
