### PR TITLE
fix: case-insensitive validation of `BUILD*` app settings

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,8 +46,8 @@ variable "app_settings" {
   }
 
   validation {
-    condition     = length(setintersection(["build", "buildNumber", "buildId"], keys(var.app_settings))) == 0
-    error_message = "Build settings (\"build*\") must be configured outside of Terraform, commonly in a CI/CD pipeline."
+    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILDNUMBER", "BUILD_ID", "BUILDID"], [for key in keys(var.app_settings) : upper(key)])) == 0
+    error_message = "Build settings (\"BUILD*\") must be configured outside of Terraform, commonly in a CI/CD pipeline."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "app_settings" {
   }
 
   validation {
-    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILDNUMBER", "BUILD_ID", "BUILDID"], [for key in keys(var.app_settings) : upper(key)])) == 0
+    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], [for key in keys(var.app_settings) : upper(key)])) == 0
     error_message = "Build settings (\"BUILD*\") must be configured outside of Terraform, commonly in a CI/CD pipeline."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,8 +46,8 @@ variable "app_settings" {
   }
 
   validation {
-    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], keys(var.app_settings))) == 0
-    error_message = "Build settings (\"BUILD_*\") must be configured outside of Terraform, commonly in a CI/CD pipeline."
+    condition     = length(setintersection(["build", "buildNumber", "buildId"], keys(var.app_settings))) == 0
+    error_message = "Build settings (\"build*\") must be configured outside of Terraform, commonly in a CI/CD pipeline."
   }
 }
 


### PR DESCRIPTION
### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
