### PR TITLE
fix: throw warning instead of error when trying to configure build related app settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Terraform module which creates an Azure Web App.
 
+## Features
+
+- Ignore changes to app settings `BUILD`, `BUILD_NUMBER` and `BUILD_ID`, allowing them to be configured outside of Terraform (commonly in a CI/CD pipeline).
+
 ## Development
 
 1. Read [this document](https://code.visualstudio.com/docs/devcontainers/containers).

--- a/main.tf
+++ b/main.tf
@@ -275,6 +275,13 @@ resource "azurerm_windows_web_app" "this" {
   }
 }
 
+check "build_settings_check" {
+  assert {
+    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], keys(var.app_settings))) == 0
+    error_message = "App settings \"BUILD\", \"BUILD_NUMBER\" and \"BUILD_ID\" should be configured outside of Terraform, commonly in a CI/CD pipeline. Any changes made to these app settings will be ignored."
+  }
+}
+
 resource "azurerm_app_service_custom_hostname_binding" "this" {
   for_each = var.custom_hostname_bindings
 

--- a/variables.tf
+++ b/variables.tf
@@ -44,11 +44,6 @@ variable "app_settings" {
     condition     = length(setintersection(["WEBSITE_HTTPLOGGING_ENABLED", "WEBSITE_HTTPLOGGING_RETENTION_DAYS", "WEBSITE_HTTPLOGGING_CONTAINER_URL"], keys(var.app_settings))) == 0
     error_message = "HTTP logging settings (\"WEBSITE_HTTPLOGGING_*\") must be configured using \"http_logs_file_system_retention_in_mb\" and \"http_logs_file_system_retention_in_days\"."
   }
-
-  validation {
-    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], [for key in keys(var.app_settings) : upper(key)])) == 0
-    error_message = "Build settings (\"BUILD*\") must be configured outside of Terraform, commonly in a CI/CD pipeline."
-  }
 }
 
 variable "application_stack" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.5.0"
 
   required_providers {
     azurerm = {


### PR DESCRIPTION
Remove custom validation rule for variable `app_settings` that prevents configuration of build settings, and instead add a check block that throws a warning to notify users that any changes made to build settings outside of Terraform will be ignored.

Here's how the warning looks when trying to configure app setting `BUILD`:

![image](https://github.com/equinor/terraform-azurerm-web-app/assets/46495473/009ea18a-6991-4df5-8b73-5d8c3a9376fd)

This is because our logic to prevent configuration of build related app settings depends on the `ignore_changes` meta-argument. A limitation of this meta-argument is that it only accepts static values. That means that to support all case variations of the three relevant settings (`BUILD`, `BUILD_NUMBER` and `BUILD_ID`), we'd need...

`BUILD`: 2^5 = 32
`BUILD_NUMBER`: 2^11 = 2048
`BUILD_ID`: 2^7 = 128
32 + 2048 + 128 = **2208 static entries in `ignore_changes`** 🙃 

So let's allow users to configure build settings, but give them a warning if they use the uppercase variant which we choose to ignore.

Check blocks were introduced in Terraform 1.5, so bumping required version.

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
