### PR TITLE
feat: deny public network access by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Terraform module which creates an Azure Web App.
 ## Features
 
 - HTTPS enforced.
+- Public network access denied by default.
 - Managed certificates automatically created for custom hostnames.
 - Application logging enabled.
 - Audit logs sent to given Log Analytics workspace by default.

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ resource "azurerm_linux_web_app" "this" {
   https_only                      = local.https_only
   client_affinity_enabled         = var.client_affinity_enabled
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
+  public_network_access_enabled   = true
   virtual_network_subnet_id       = var.virtual_network_subnet_id
 
   tags = var.tags
@@ -166,6 +167,7 @@ resource "azurerm_windows_web_app" "this" {
   https_only                      = local.https_only
   client_affinity_enabled         = var.client_affinity_enabled
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
+  public_network_access_enabled   = true
   virtual_network_subnet_id       = var.virtual_network_subnet_id
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -160,15 +160,25 @@ variable "ip_restrictions" {
 }
 
 variable "ip_restriction_default_action" {
-  description = "The default action for traffic that does not match any IP restriction rule."
+  description = "The default action for traffic that does not match any IP restriction rule. Value must be \"Allow\" or \"Deny\"."
   type        = string
-  default     = "Allow"
+  default     = "Deny"
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.ip_restriction_default_action)
+    error_message = "IP restriction default action must be \"Allow\" or \"Deny\"."
+  }
 }
 
 variable "scm_ip_restriction_default_action" {
-  description = "The default action for traffic to the Source Control Manager (SCM) that does not match any IP restriction rule."
+  description = "The default action for traffic to the Source Control Manager (SCM) that does not match any IP restriction rule. Value must be \"Allow\" or \"Deny\"."
   type        = string
-  default     = "Allow"
+  default     = "Deny"
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.scm_ip_restriction_default_action)
+    error_message = "SCM IP restriction default action must be \"Allow\" or \"Deny\"."
+  }
 }
 
 variable "application_logs_file_system_level" {


### PR DESCRIPTION
Increase out-of-box security by denying all public network access by default.

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
