### PR TITLE
feat: configure client certificate and public network access

### DIFF
--- a/examples/linux-app/main.tf
+++ b/examples/linux-app/main.tf
@@ -8,7 +8,6 @@ resource "random_id" "this" {
 
 module "log_analytics" {
   source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.4.0"
-  count = var.logs_analytics_enable ? 1 : 0
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = var.resource_group_name
@@ -30,6 +29,6 @@ module "web_app" {
   resource_group_name        = var.resource_group_name
   location                   = var.location
   app_service_plan_id        = module.app_service.plan_id
-  log_analytics_workspace_id = var.logs_analytics_enable ? module.log_analytics[0].workspace_id : null
+  log_analytics_workspace_id = module.log_analytics.workspace_id
   
 }

--- a/examples/linux-app/main.tf
+++ b/examples/linux-app/main.tf
@@ -8,6 +8,7 @@ resource "random_id" "this" {
 
 module "log_analytics" {
   source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.4.0"
+  count = var.logs_analytics_enable ? 1 : 0
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = var.resource_group_name
@@ -29,5 +30,6 @@ module "web_app" {
   resource_group_name        = var.resource_group_name
   location                   = var.location
   app_service_plan_id        = module.app_service.plan_id
-  log_analytics_workspace_id = module.log_analytics.workspace_id
+  log_analytics_workspace_id = var.logs_analytics_enable ? module.log_analytics[0].workspace_id : null
+  
 }

--- a/examples/linux-app/variables.tf
+++ b/examples/linux-app/variables.tf
@@ -7,3 +7,10 @@ variable "location" {
   description = "The name of the location to create the resources in."
   type        = string
 }
+
+variable "logs_analytics_enable" {
+  description = "Should logs_analytics be enable for the web app?"
+  default = true
+  type = bool
+  
+}

--- a/examples/linux-app/variables.tf
+++ b/examples/linux-app/variables.tf
@@ -7,10 +7,3 @@ variable "location" {
   description = "The name of the location to create the resources in."
   type        = string
 }
-
-variable "logs_analytics_enable" {
-  description = "Should logs_analytics be enable for the web app?"
-  default = true
-  type = bool
-  
-}

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,8 @@ resource "azurerm_linux_web_app" "this" {
   count = local.is_windows ? 0 : 1
 
   name                            = var.app_name
+  client_certificate_enabled      = var.client_certificate_enabled
+  client_certificate_mode         = var.client_certificate_mode
   location                        = var.location
   resource_group_name             = var.resource_group_name
   service_plan_id                 = var.app_service_plan_id
@@ -11,7 +13,7 @@ resource "azurerm_linux_web_app" "this" {
   https_only                      = local.https_only
   client_affinity_enabled         = var.client_affinity_enabled
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
-  public_network_access_enabled   = true
+  public_network_access_enabled   = var.public_network_access_enabled
   virtual_network_subnet_id       = var.virtual_network_subnet_id
 
   tags = var.tags
@@ -147,6 +149,8 @@ resource "azurerm_windows_web_app" "this" {
   count = local.is_windows ? 1 : 0
 
   name                            = var.app_name
+  client_certificate_enabled      = var.client_certificate_enabled
+  client_certificate_mode         = var.client_certificate_mode
   location                        = var.location
   resource_group_name             = var.resource_group_name
   service_plan_id                 = var.app_service_plan_id
@@ -154,7 +158,7 @@ resource "azurerm_windows_web_app" "this" {
   https_only                      = local.https_only
   client_affinity_enabled         = var.client_affinity_enabled
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
-  public_network_access_enabled   = true
+  public_network_access_enabled   = var.public_network_access_enabled
   virtual_network_subnet_id       = var.virtual_network_subnet_id
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -316,3 +316,22 @@ variable "storage_accounts" {
     error_message = "Storage account type must be either \"AzureFiles\" or \"AzureBlob\"."
   }
 }
+
+variable "public_network_access_enabled" {
+    description = "Should public access be enabled for this Web App?"
+    default = true
+    type = bool
+}
+
+
+variable "client_certificate_mode" {
+  description = "Should client cerftificate mode be enabled for this Web App?"
+  default = "Optional"
+  type = string
+}
+
+variable "client_certificate_enabled" {
+  description = "Should client certificate be enabled for this Web App?"
+  default = false
+  type = bool
+}


### PR DESCRIPTION
We used this module internally and made some changes which need to be compliant as per internal compliance policy.

Below are the changes -

**log_analytics_workspace_id** was mandate before now we have added a variable to handle it if this can be used or can be skip using the following  **logs_analytics_enable**.

We have added 2 more attributes to the webapp **client_certificate_mode & client_certificate_enabled** and we parameterized this attribute the **public_network_access_enabled**.

We have done a testing with these changes and it is working as expected.

