### PR TITLE
fix: prevent configuration of hidden tags

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -290,6 +290,11 @@ variable "tags" {
   description = "A map of tags to assign to the resources."
   type        = map(string)
   default     = {}
+
+  validation {
+    condition     = length(setintersection(["hidden-link: /app-insights-conn-string", "hidden-link: /app-insights-instrumentation-key", "hidden-link: /app-insights-resource-id"], keys(var.tags))) == 0
+    error_message = "Hidden tags (\"hidden-link: *\") are managed by Azure."
+  }
 }
 
 variable "storage_accounts" {


### PR DESCRIPTION
Hidden tags are managed by Azure.

Changes to these tags are ignored anyway (#218).
