### PR TITLE
fix: app settings implicitly managed by Terraform lost during update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Terraform module which creates Azure Web App resources.
 - Linux Web App created by default.
 - HTTPS enforced.
 - Public network access denied by default.
-- App settings updated incrementally, allowing configuration outside of Terraform (e.g. in a CI/CD pipeline).
+- App settings incrementally updated, allowing configuration outside of Terraform (e.g. in a CI/CD pipeline).
 - Managed certificates automatically created for custom hostnames.
 - Application logging enabled (automatically disabled after 12 hours, see [notes](#application-logging)).
 - Audit logs sent to given Log Analytics workspace by default.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Terraform module which creates Azure Web App resources.
 - Linux Web App created by default.
 - HTTPS enforced.
 - Public network access denied by default.
+- App settings updated incrementally, allowing configuration outside of Terraform (e.g. in a CI/CD pipeline).
 - Managed certificates automatically created for custom hostnames.
 - Application logging enabled (automatically disabled after 12 hours, see [notes](#application-logging)).
 - Audit logs sent to given Log Analytics workspace by default.
-- Changes to app settings `BUILD`, `BUILD_NUMBER` and `BUILD_ID` ignored, allowing them to be configured outside of Terraform (commonly in a CI/CD pipeline).
 
 ## Prerequisites
 

--- a/main.tf
+++ b/main.tf
@@ -364,21 +364,30 @@ resource "azurerm_windows_web_app" "this" {
   }
 }
 
-# Manage app settings using the AzAPI provider instead of AzureRM.
-# This enables the possibility of managing app settings either in Terraform or outside Terraform.
-# Ref: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/2022-09-01/sites/config-appsettings?pivots=deployment-language-terraform
-#
-# An issue has been created for a standalone "app_settings" resource to be implemented in the AzureRM provider.
-# Ref: https://github.com/hashicorp/terraform-provider-azurerm/issues/28497
-resource "azapi_update_resource" "app_settings" {
+data "azapi_resource_id" "app_settings" {
   type      = "Microsoft.Web/sites/config@2022-09-01"
-  name      = "appsettings"
   parent_id = local.web_app.id
+  name      = "appsettings"
+}
+
+# Getting app settings directly from the Web App resource state does not include app settings that are implicitly managed by Terraform (e.g. "DOCKER_REGISTRY_SERVER_URL").
+data "azapi_resource_action" "list_app_settings" {
+  type        = "Microsoft.Web/sites/config@2022-09-01"
+  resource_id = data.azapi_resource_id.app_settings.id
+  action      = "list"
+  method      = "POST"
+
+  response_export_values = ["properties"]
+}
+
+resource "azapi_update_resource" "app_settings" {
+  type        = "Microsoft.Web/sites/config@2022-09-01"
+  resource_id = data.azapi_resource_id.app_settings.id
 
   body = {
     # Apply app settings managed in Terraform on top of app settings managed outside of Terraform.
     # Ensures that app settings managed outside of Terraform are not lost.
-    properties = merge(local.web_app.app_settings, var.app_settings)
+    properties = merge(data.azapi_resource_action.list_app_settings.output.properties, var.app_settings)
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_linux_web_app" "this" {
   location                        = var.location
   resource_group_name             = var.resource_group_name
   service_plan_id                 = var.app_service_plan_id
-  app_settings                    = var.app_settings
+  app_settings                    = null # Manage using standalone resource instead.
   https_only                      = local.https_only
   client_affinity_enabled         = var.client_affinity_enabled
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
@@ -151,11 +151,9 @@ resource "azurerm_linux_web_app" "this" {
       # Ignore changes to prevent cycle of turning on/off...
       logs[0].application_logs,
 
-      # Ignore changes to common build settings.
-      # These are usually configured in CI/CD pipelines.
-      app_settings["BUILD"],
-      app_settings["BUILD_NUMBER"],
-      app_settings["BUILD_ID"],
+      # Ignore changes to app settings.
+      # Manage using standalone resource instead.
+      app_settings,
 
       # Ignore changes to hidden tags that are managed by Azure.
       tags["hidden-link: /app-insights-conn-string"],
@@ -183,7 +181,7 @@ resource "azurerm_windows_web_app" "this" {
   location                        = var.location
   resource_group_name             = var.resource_group_name
   service_plan_id                 = var.app_service_plan_id
-  app_settings                    = var.app_settings
+  app_settings                    = null # Manage using standalone resource instead.
   https_only                      = local.https_only
   client_affinity_enabled         = var.client_affinity_enabled
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
@@ -345,11 +343,9 @@ resource "azurerm_windows_web_app" "this" {
       # Ignore changes to prevent cycle of turning on/off...
       logs[0].application_logs,
 
-      # Ignore changes to common build settings.
-      # These are usually configured in CI/CD pipelines.
-      app_settings["BUILD"],
-      app_settings["BUILD_NUMBER"],
-      app_settings["BUILD_ID"],
+      # Ignore changes to app settings.
+      # Manage using standalone resource instead.
+      app_settings,
 
       # Ignore changes to hidden tags that are managed by Azure.
       tags["hidden-link: /app-insights-conn-string"],
@@ -368,10 +364,21 @@ resource "azurerm_windows_web_app" "this" {
   }
 }
 
-check "build_settings_check" {
-  assert {
-    condition     = length(setintersection(["BUILD", "BUILD_NUMBER", "BUILD_ID"], keys(var.app_settings))) == 0
-    error_message = "App settings \"BUILD\", \"BUILD_NUMBER\" and \"BUILD_ID\" should be configured outside of Terraform, commonly in a CI/CD pipeline. Any changes made to these app settings will be ignored."
+# Manage app settings using the AzAPI provider instead of AzureRM.
+# This enables the possibility of managing app settings either in Terraform or outside Terraform.
+# Ref: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/2022-09-01/sites/config-appsettings?pivots=deployment-language-terraform
+#
+# An issue has been created for a standalone "app_settings" resource to be implemented in the AzureRM provider.
+# Ref: https://github.com/hashicorp/terraform-provider-azurerm/issues/28497
+resource "azapi_update_resource" "app_settings" {
+  type      = "Microsoft.Web/sites/config@2022-09-01"
+  name      = "appsettings"
+  parent_id = local.web_app.id
+
+  body = {
+    # Apply app settings managed in Terraform on top of app settings managed outside of Terraform.
+    # Ensures that app settings managed outside of Terraform are not lost.
+    properties = merge(local.web_app.app_settings, var.app_settings)
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.95.0"
     }
+
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 2.0"
+    }
   }
 }


### PR DESCRIPTION
A second attempt at implementing incremental updates of app settings.

First attempt at an implementation was in #246, however we experienced that app settings implicitly managed by Terraform (e.g. `DOCKER_REGISTRY_SERVER_URL`) were lost during updates. As a result, this change was reverted in 377f2c227926fe4f684849109b2da05cf19c8935.

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
