### PR TITLE
feat: add variable `scm_ip_restrictions`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,19 @@ resource "azurerm_linux_web_app" "this" {
       }
     }
 
+    dynamic "scm_ip_restriction" {
+      for_each = var.scm_ip_restrictions
+
+      content {
+        action      = scm_ip_restriction.value.action
+        headers     = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+        ip_address  = scm_ip_restriction.value.ip_address
+        name        = scm_ip_restriction.value.name
+        priority    = scm_ip_restriction.value.priority
+        service_tag = scm_ip_restriction.value.service_tag
+      }
+    }
+
     dynamic "application_stack" {
       for_each = var.application_stack == null ? toset([]) : toset([var.application_stack])
 
@@ -257,6 +270,19 @@ resource "azurerm_windows_web_app" "this" {
         name        = ip_restriction.value.name
         priority    = ip_restriction.value.priority
         service_tag = ip_restriction.value.service_tag
+      }
+    }
+
+    dynamic "scm_ip_restriction" {
+      for_each = var.scm_ip_restrictions
+
+      content {
+        action      = scm_ip_restriction.value.action
+        headers     = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+        ip_address  = scm_ip_restriction.value.ip_address
+        name        = scm_ip_restriction.value.name
+        priority    = scm_ip_restriction.value.priority
+        service_tag = scm_ip_restriction.value.service_tag
       }
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -224,6 +224,27 @@ variable "ip_restriction_default_action" {
   }
 }
 
+variable "scm_ip_restrictions" {
+  description = "A list of IP restrictions to be configured for the Source Control Manager (SCM)."
+
+  type = list(object({
+    action      = optional(string, "Allow")
+    ip_address  = optional(string)
+    name        = string
+    priority    = number
+    service_tag = optional(string)
+
+    headers = optional(object({
+      x_forwarded_for   = optional(list(string))
+      x_forwarded_host  = optional(list(string))
+      x_azure_fdid      = optional(list(string))
+      x_fd_health_probe = optional(list(string))
+    }))
+  }))
+
+  default = []
+}
+
 variable "scm_ip_restriction_default_action" {
   description = "The default action for traffic to the Source Control Manager (SCM) that does not match any IP restriction rule. Value must be \"Allow\" or \"Deny\"."
   type        = string


### PR DESCRIPTION
Currently we deny all traffic to the Source Control Manager (SCM) by default. The only option to allow any traffic is to allow *all* traffic by setting the value of variable `scm_ip_restriction_default_action` to `"Allow"`.

Add variable `scm_ip_restrictions` that can be used to allow *specific* traffic instead of all traffic.

### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
