### PR TITLE
fix(database): reference to dynamic block iterator `metric` should be `enabled_metric`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -443,7 +443,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     for_each = toset(var.diagnostic_setting_enabled_metric_categories)
 
     content {
-      category = metric.value
+      category = enabled_metric.value
     }
   }
 }


### PR DESCRIPTION
### Checklist

- [x] I've updated both the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources.
